### PR TITLE
fix: Fixing microsecond precision constant for v1 (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
+## Version 3.x.x
+ - [FIX] Compilation error on fields order (#43)
+ - [FIX] Invalid precision constant for microseconds (#49)
+
+## Version 3.1.1
+- [Updated] CA Certificate for SSL (#38)
 
 ## Version 3.1.0
- - [NEW] user-agent header added
+ - [NEW] Added User-agent header
  - [FIX] status code check when pinging an InfluxDB version 1.x instance
 
 ## Version 3.0.0

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -57,10 +57,10 @@ static String escapeKey(String key);
 static String escapeValue(const char *value);
 static String escapeJSONString(String &value);
 
-static String precisionToString(WritePrecision precision) {
+static String precisionToString(WritePrecision precision, uint8_t version = 2) {
     switch(precision) {
         case WritePrecision::US:
-            return "us";
+            return version==1?"u":"us";
         case WritePrecision::MS:
             return "ms";
         case WritePrecision::NS:
@@ -266,7 +266,7 @@ void InfluxDBClient::setUrls() {
         }
     }
     if(_writePrecision != WritePrecision::NoTime) {
-        _writeUrl += String("&precision=") + precisionToString(_writePrecision);
+        _writeUrl += String("&precision=") + precisionToString(_writePrecision, _dbVersion);
     }
     
 }

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -231,26 +231,36 @@ function handleAuthentication(req, res) {
     }
 }
 
+const AllowedPrecisions = ['ns','us','ms','s'];
 function checkWriteParams(req, res) {
     var org = req.query['org'];
     var bucket = req.query['bucket'];
+    var precision = req.query['precision'];
     if(org != 'my-org') {
         res.status(404).send(`{"code":"not found","message":"organization name \"${org}\" not found"}`);
         return false;
     } else if(bucket != 'my-bucket') {
         res.status(404).send(`{"code":"not found","message":"bucket \"${bucket}\" not found"}`);
         return false;
+    } else if(typeof precision !== 'undefined' && AllowedPrecisions.indexOf(precision)==-1) {
+        res.status(400).send(`{"code":"bad request ","message":"precision \"${precision}\" is not valid"}`);
+        return false;
     } else {
         return true;
     }
 }
 
+const AllowedPrecisionsV1 = ['ns','u','ms','s'];
 function checkWriteParamsV1(req, res) {
     var db = req.query['db'];
+    var precision = req.query['precision'];
     if(db != 'my-db') {
         res.status(404).send(`{"code":"not found","message":"database \"${db}\" not found"}`);
         return false;
-    } else {
+    } else if(typeof precision !== 'undefined' && AllowedPrecisionsV1.indexOf(precision)==-1) {
+        res.status(400).send(`{"code":"bad request ","message":"precision \"${precision}\" is not valid"}`);
+        return false;
+    }else {
         return true;
     }
 }

--- a/test/test.ino
+++ b/test/test.ino
@@ -176,6 +176,15 @@ void testBasicFunction() {
     String q = queryFlux(client.getServerUrl(),INFLUXDB_CLIENT_TESTING_TOK, INFLUXDB_CLIENT_TESTING_ORG, query);
     TEST_ASSERT(countLines(q) == 6);  //5 points+header
 
+    // test precision
+    for (int i = (int)WritePrecision::NoTime; i <= (int)WritePrecision::NS; i++) {
+        client.setWriteOptions((WritePrecision)i, 1);
+        Point *p = createPoint("test1");
+        p->addField("index", i);
+        TEST_ASSERTM(client.writePoint(*p), String("i=") + i);
+        delete p;
+    }
+
     TEST_END();
     deleteAll(INFLUXDB_CLIENT_TESTING_URL);
 }
@@ -768,6 +777,15 @@ void testV1() {
     q = queryFlux(client.getServerUrl(),INFLUXDB_CLIENT_TESTING_TOK, INFLUXDB_CLIENT_TESTING_ORG, query);
     lines = getLines(q, count);
     TEST_ASSERT(count == 16);  
+
+    // test precision
+    for (int i = (int)WritePrecision::NoTime; i <= (int)WritePrecision::NS; i++) {
+        client.setWriteOptions((WritePrecision)i, 1);
+        Point *p = createPoint("test1");
+        p->addField("index", i);
+        TEST_ASSERTM(client.writePoint(*p), String("i=") + i);
+        delete p;
+    }
     TEST_END();
     deleteAll(INFLUXDB_CLIENT_TESTING_URL);
 }


### PR DESCRIPTION
Although write protocol is the same for both InflluxDB v1 and  v2, there is an incompatibility in precision constant for microseconds used in the write URL, `u` for v1 vs. `us` for v2. 
Unfortunately,  due to the InfluxDB v1 issue [#17622](https://github.com/influxdata/influxdb/issues/17622), the wrong precision constant is not reported back.
This fix creates a workaround for that. Fixes #49