### PR TITLE
fix: Correct pointer type for UserAgent string (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
-
+## Version 3.1.x
+ - [FIX] SecureWrite crash (#54)
+ 
 ## Version 3.1.2 (2020-04-18)
  - [FIX] Compilation error on fields order (#43)
  - [FIX] Invalid precision constant for microseconds (#49)

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -227,7 +227,7 @@ bool InfluxDBClient::init() {
     }
     _httpClient.setReuse(false);
 
-    _httpClient.setUserAgent(UserAgent);
+    _httpClient.setUserAgent(FPSTR(UserAgent));
     return true;
 }
 


### PR DESCRIPTION
Closes #54.

Verified on two D1 minis and an ESP32 Dev Kit V1. Quite weird it worked correctly before. 