### PR TITLE
feat: Refactored options and added HTTP read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## Version 3.4.0 (in progres)
 ### Features
  - [#89](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/89) - ESP8266 only - Added Max Fragment Length Negotiation for TLS communicaton to reduce memory allocation. If server supports MFLN, it saves ~15kB. Standalone InfluxDB OSS server doesn't support MFLN, Cloud yes. To leverage MFLN for standalone OSS, a reverse proxy needs to be used. 
+ - [#91](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/91) - Improved API for settings of write and HTTP options:
+  - Introduced `WriteOptions` to wrap the write related options (write precision, batch-size, etc). It offers fluent style API allowing to change only the required options. `InfluxDBClient` has overloaded `setWriteOptions(const WriteOptions& writeOptions)` method.
+  - Introduced `HTTPOptions` to wrap the HTTP related options (e.g. reusing connection). It offers fluent style API allowing to change only the required options. `InfluxDBClient` has `setHTTPOptions(const HTTPOptions& httpOptions)` method.
+  - Added possibility to set HTTP response read timeout (part of the `HTTPOptions`).
+  - Method `InfluxDBClient::void setWriteOptions(WritePrecision precision, uint16_t batchSize = 1, uint16_t bufferSize = 5, uint16_t flushInterval = 60, bool preserveConnection = true)` is deprecated and it will be removed in the next release.
 
 ### Documentation
  - [#87](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/87) - Fixed include file name in the Readme

--- a/examples/SecureBatchWrite/SecureBatchWrite.ino
+++ b/examples/SecureBatchWrite/SecureBatchWrite.ino
@@ -93,7 +93,7 @@ void setup() {
   }
 
   // Enable messages batching and retry buffer
-  client.setWriteOptions(WRITE_PRECISION, MAX_BATCH_SIZE, WRITE_BUFFER_SIZE);
+  client.setWriteOptions(WriteOptions().writePrecision(WRITE_PRECISION).batchSize(MAX_BATCH_SIZE).bufferSize(WRITE_BUFFER_SIZE));
 }
 
 void loop() {

--- a/src/InfluxDb.cpp
+++ b/src/InfluxDb.cpp
@@ -122,10 +122,10 @@ void Influxdb::begin() {
  */
 void Influxdb::prepare(InfluxData data) { 
   ++_preparedPoints;
-  if(_batchSize <= _preparedPoints) {
+  if(_writeOptions._batchSize <= _preparedPoints) {
     // for preparation, batchsize must be greater than number of prepared points, or it will send data right away
-    _batchSize = _preparedPoints+1;
-    reserveBuffer(2*_batchSize);
+    _writeOptions._batchSize = _preparedPoints+1;
+    reserveBuffer(2*_writeOptions._batchSize);
   }
   write(data);
 }

--- a/src/Options.h
+++ b/src/Options.h
@@ -1,0 +1,92 @@
+/**
+ * 
+ * Options.h: InfluxDB Client write options and HTTP options
+ * 
+ * MIT License
+ * 
+ * Copyright (c) 2020 InfluxData
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+#ifndef _OPTIONS_H_
+#define _OPTIONS_H_
+
+#include "WritePrecision.h"
+
+class InfluxDBClient;
+class Influxdb;
+class Test;
+
+/**
+ * WriteOptions holds write related options
+ */
+class WriteOptions {
+private:
+    friend class InfluxDBClient;
+    friend class Influxdb;
+    friend class Test;
+    // Points timestamp precision
+    WritePrecision _writePrecision; 
+    // Number of points that will be written to the databases at once. 
+    // Default 1 (immediate write, no batching)
+    uint16_t _batchSize;
+    // Write buffer size - maximum number of record to keep.
+    // When max size is reached, oldest records are overwritten.
+    // Default 5
+    uint16_t _bufferSize;
+    // Maximum number of seconds points can be held in buffer before are written to the db. 
+    // Buffer is flushed when it reaches batch size or when flush interval runs out. 
+    uint16_t _flushInterval;
+public:
+    WriteOptions():
+        _writePrecision(WritePrecision::NoTime),
+        _batchSize(1),
+        _bufferSize(5),
+        _flushInterval(60) {
+        }
+    WriteOptions& writePrecision(WritePrecision precision) { _writePrecision = precision; return *this; }
+    WriteOptions& batchSize(uint16_t batchSize) { _batchSize = batchSize; return *this; }
+    WriteOptions& bufferSize(uint16_t bufferSize) { _bufferSize = bufferSize; return *this; }
+    WriteOptions& flushIntervalSec(uint16_t flushIntervalSec) { _flushInterval = flushIntervalSec; return *this; }
+};
+
+/**
+ * HTTPOptions holds HTTP related options
+ */
+class HTTPOptions {
+private:    
+    friend class InfluxDBClient;
+    friend class Influxdb;
+    friend class Test;
+    // true if HTTP connection should be kept open. Usable for frequent writes.
+    // Default false.
+    bool _connectionReuse;
+    // Timeout (ms) for reading server response.
+    // Default 5000ms.s  
+    int _httpReadTimeout;
+public:
+    HTTPOptions():
+        _connectionReuse(false),
+        _httpReadTimeout(5000) {
+        }
+    HTTPOptions& connectionReuse(bool connectionReuse) { _connectionReuse = connectionReuse; return *this; }
+    HTTPOptions& httpReadTimeout(int httpReadTimeoutMs) { _httpReadTimeout = httpReadTimeoutMs; return *this; }
+};
+
+#endif //_OPTIONS_H_

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -1,0 +1,114 @@
+/**
+ * 
+ * Point.cpp: Point for write into InfluxDB server
+ * 
+ * MIT License
+ * 
+ * Copyright (c) 2020 InfluxData
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
+#include "Point.h"
+#include "util/helpers.h"
+
+Point::Point(String measurement):
+    _measurement(escapeKey(measurement, false)),
+    _tags(""),
+    _fields(""),
+    _timestamp("")
+{
+
+}
+
+void Point::addTag(String name, String value) {
+    if(_tags.length() > 0) {
+        _tags += ',';
+    }
+    _tags += escapeKey(name);
+    _tags += '=';
+    _tags += escapeKey(value);
+}
+
+void Point::addField(String name, const char *value) { 
+    putField(name, "\"" + escapeValue(value) + "\""); 
+}
+
+void Point::putField(String name, String value) {
+    if(_fields.length() > 0) {
+        _fields += ',';
+    }
+    _fields += escapeKey(name);
+    _fields += '=';
+    _fields += value;
+}
+
+String Point::toLineProtocol() const {
+    String line =  _measurement;
+    if(hasTags()) {
+        line += "," + _tags;
+    }
+    if(hasFields()) {
+        line += " " + _fields;
+    }
+    if(hasTime()) {
+        line += " " + _timestamp;
+    }
+    return line;
+}
+
+void  Point::setTime(WritePrecision precision) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    
+    switch(precision) {
+        case WritePrecision::NS:
+            setTime(getTimeStamp(&tv,9));
+            break;
+        case WritePrecision::US:
+            setTime(getTimeStamp(&tv,6));
+            break;
+        case WritePrecision::MS: 
+            setTime(getTimeStamp(&tv,3));
+            break;
+        case WritePrecision::S:
+            setTime(getTimeStamp(&tv,0));
+            break;
+        case WritePrecision::NoTime:
+            _timestamp = "";
+            break;
+    }
+}
+
+void  Point::setTime(unsigned long long timestamp) {
+    _timestamp = timeStampToString(timestamp);
+}
+
+void  Point::setTime(String timestamp) {
+    _timestamp = timestamp;
+}
+
+void  Point::clearFields() {
+    _fields = "";
+    _timestamp = "";
+}
+
+void Point:: clearTags() {
+    _tags = "";
+}

--- a/src/Point.h
+++ b/src/Point.h
@@ -1,0 +1,82 @@
+/**
+ * 
+ * Point.h: Point for write into InfluxDB server
+ * 
+ * MIT License
+ * 
+ * Copyright (c) 2020 InfluxData
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+#ifndef _POINT_H_
+#define _POINT_H_
+
+#include <Arduino.h>
+#include "WritePrecision.h"
+
+/**
+ * Class Point represents InfluxDB point in line protocol.
+ * It defines data to be written to InfluxDB.
+ */
+class Point {
+  public:
+    Point(String measurement);
+    // Adds string tag 
+    void addTag(String name, String value);
+    // Add field with various types
+    void addField(String name, float value, int decimalPlaces = 2)         { if(!isnan(value)) putField(name, String(value, decimalPlaces)); }
+    void addField(String name, double value)        { if(!isnan(value)) putField(name, String(value)); }
+    void addField(String name, char value)          { addField(name, String(value).c_str()); }
+    void addField(String name, unsigned char value) { putField(name, String(value)+"i"); }
+    void addField(String name, int value)           { putField(name, String(value)+"i"); }
+    void addField(String name, unsigned int value)  { putField(name, String(value)+"i"); }
+    void addField(String name, long value)          { putField(name, String(value)+"i"); }
+    void addField(String name, unsigned long value) { putField(name, String(value)+"i"); }
+    void addField(String name, bool value)          { putField(name,value?"true":"false"); }
+    void addField(String name, String value)        { addField(name, value.c_str()); }
+    void addField(String name, const char *value);
+    // Set timestamp to `now()` and store it in specified precision, nanoseconds by default. Date and time must be already set. See `configTime` in the device API
+    void setTime(WritePrecision writePrecision = WritePrecision::NS);
+    // Set timestamp in offset since epoch (1.1.1970). Correct precision must be set InfluxDBClient::setWriteOptions.
+    void setTime(unsigned long long timestamp);
+    // Set timestamp in offset since epoch (1.1.1970 00:00:00). Correct precision must be set InfluxDBClient::setWriteOptions.
+    void setTime(String timestamp);
+    // Clear all fields. Usefull for reusing point  
+    void clearFields();
+    // Clear tags
+    void clearTags();
+    // True if a point contains at least one field. Points without a field cannot be written to db
+    bool hasFields() const { return _fields.length() > 0; }
+    // True if a point contains at least one tag
+    bool hasTags() const   { return _tags.length() > 0; }
+    // True if a point contains timestamp
+    bool hasTime() const   { return _timestamp.length() > 0; }
+    // Creates line protocol
+    String toLineProtocol() const;
+    // returns current timestamp
+    String getTime() const { return _timestamp; } 
+  protected:
+    String _measurement;
+    String _tags;
+    String _fields;
+    String _timestamp;    
+    // method for formating field into line protocol
+    void putField(String name, String value);
+};
+#endif //_POINT_H_

--- a/src/WritePrecision.h
+++ b/src/WritePrecision.h
@@ -1,0 +1,43 @@
+/**
+ * 
+ * WritePrecision.h: Write precision for InfluxDB Client for Arduino
+ * 
+ * MIT License
+ * 
+ * Copyright (c) 2020 InfluxData
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+#ifndef _WRITE_PRECISION_H_
+#define _WRITE_PRECISION_H_
+// Enum WritePrecision defines constants for specifying InfluxDB write prcecision
+enum class WritePrecision  {
+  // Specifyies that points has no timestamp (default). Server will assign timestamp. 
+  NoTime = 0,
+  // Seconds
+  S,
+  // Milli-seconds 
+  MS,
+  // Micro-seconds 
+  US,
+  // Nano-seconds
+  NS
+};
+
+#endif //_WRITE_PRECISION_H_

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -7,6 +7,7 @@ const port = 999;
 var pointsdb = []; 
 var lastUserAgent = '';
 var chunked = false;
+var delay = 0;
 
 app.use (function(req, res, next) {
     var data='';
@@ -86,6 +87,11 @@ app.post('/api/v2/write', (req,res) => {
                         break;
                     case 'chunked':
                         chunked = true;
+                        console.log("Set chunked = true");
+                        break;
+                    case 'timeout':
+                        delay = parseInt(point.tags.timeout)*1000;
+                        console.log("Set delay: " + delay);
                         break;
                 }
                 points.shift();
@@ -225,6 +231,14 @@ var queryRes = {
 "empty":``
 };
 
+function sleep(milliseconds) {
+    const date = Date.now();
+    let currentDate = null;
+    do {
+      currentDate = Date.now();
+    } while (currentDate - date < milliseconds);
+  }
+
 app.post('/api/v2/query', (req,res) => {
     //console.log("Query with: " + req.body);
     if(checkQueryParams(req, res) && handleAuthentication(req, res)) {
@@ -243,6 +257,10 @@ app.post('/api/v2/query', (req,res) => {
             data = convertToCSV(pointsdb);
         }
         if(data.length > 0) {
+            if(delay) {
+                sleep(delay);
+                delay = 0;
+            }
             //console.log(data);
 
             if(chunked) {


### PR DESCRIPTION
Improved API for settings of write and HTTP options:
  - Introduced `WriteOptions` to wrap the write related options (write precision, batch-size, etc). It offers fluent style API allowing to change only the required options. `InfluxDBClient` has overloaded `setWriteOptions(const WriteOptions& writeOptions)` method.
  - Introduced `HTTPOptions` to wrap the HTTP related options (e.g. reusing connection). It offers fluent style API allowing to change only the required options. `InfluxDBClient` has `setHTTPOptions(const HTTPOptions& httpOptions)` method.
  - Added possibility to set HTTP response read timeout (part of the `HTTPOptions`).
  - Method `InfluxDBClient::void setWriteOptions(WritePrecision precision, uint16_t batchSize = 1, uint16_t bufferSize = 5, uint16_t flushInterval = 60, bool preserveConnection = true)` is deprecated and it will be removed in the next release.