### PR TITLE
feat: changing default v2 port 9999->8086

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supported devices: ESP8266 (2.7+) and ESP32 (1.0.3+).
 ## Basic code for InfluxDB 2
 Using client is very easy. After [seting up InfluxDB 2 server](https://v2.docs.influxdata.com/v2.0/get-started), first define connection parameters and a client instance:
 ```cpp
-// InfluxDB 2 server url, e.g. http://192.168.1.48:9999 (Use: InfluxDB UI -> Load Data -> Client Libraries)
+// InfluxDB 2 server url, e.g. http://192.168.1.48:8086 (Use: InfluxDB UI -> Load Data -> Client Libraries)
 #define INFLUXDB_URL "influxdb-url"
 // InfluxDB 2 server or cloud API authentication token (Use: InfluxDB UI -> Load Data -> Tokens -> <select token>)
 #define INFLUXDB_TOKEN "token"
@@ -477,7 +477,7 @@ Complete source code is available in [QueryAggregated example](examples/QueryAgg
 
  // connect to WiFi
 
- Influxdb influx(INFLUXDB_HOST); // port defaults to 8086, use 9999 for v2
+ Influxdb influx(INFLUXDB_HOST); // port defaults to 8086
  // or to use a custom port
  Influxdb influx(INFLUXDB_HOST, INFLUXDB_PORT);
 
@@ -491,7 +491,7 @@ influx.setVersion(2);
 influx.setOrg("myOrganization");
 influx.setBucket("myBucket");
 influx.setToken("myToken");
-influx.setPort(9999);
+influx.setPort(8086);
 ```
 
 ### Sending a single measurement

--- a/examples/BasicWrite/BasicWrite.ino
+++ b/examples/BasicWrite/BasicWrite.ino
@@ -25,8 +25,7 @@ ESP8266WiFiMulti wifiMulti;
 // WiFi password
 #define WIFI_PASSWORD "password"
 // InfluxDB  server url. Don't use localhost, always server name or ip address.
-// For InfluxDB 2 e.g. http://192.168.1.48:9999 (Use: InfluxDB UI -> Load Data -> Client Libraries), 
-// For InfluxDB 1 e.g. http://192.168.1.48:8086
+// E.g. http://192.168.1.48:8086 (In InfluxDB 2 UI -> Load Data -> Client Libraries), 
 #define INFLUXDB_URL "influxdb-url"
 // InfluxDB 2 server or cloud API authentication token (Use: InfluxDB UI -> Load Data -> Tokens -> <select token>)
 #define INFLUXDB_TOKEN "toked-id"

--- a/examples/QueryAggregated/QueryAggregated.ino
+++ b/examples/QueryAggregated/QueryAggregated.ino
@@ -35,7 +35,7 @@ ESP8266WiFiMulti wifiMulti;
 // InfluxDB 1.8+ (v2 compatibility API) use form user:password, eg. admin:adminpass
 #define INFLUXDB_TOKEN "server token"
 // InfluxDB v2 organization name or id (Use: InfluxDB UI -> Settings -> Profile -> <name under tile> )
-// InfluxDB 1.8+ (v2 compatibility API) leave empty 
+// InfluxDB 1.8+ (v2 compatibility API) use any non empty string
 #define INFLUXDB_ORG "org name/id"
 // InfluxDB v2 bucket name (Use: InfluxDB UI -> Load Data -> Buckets)
 // InfluxDB 1.8+ (v2 compatibility API) use database name

--- a/examples/QueryTable/QueryTable.ino
+++ b/examples/QueryTable/QueryTable.ino
@@ -35,7 +35,7 @@ ESP8266WiFiMulti wifiMulti;
 // InfluxDB 1.8+ (v2 compatibility API) use form user:password, eg. admin:adminpass
 #define INFLUXDB_TOKEN "server token"
 // InfluxDB v2 organization name or id (Use: InfluxDB UI -> Settings -> Profile -> <name under tile> )
-// InfluxDB 1.8+ (v2 compatibility API) leave empty 
+// InfluxDB 1.8+ (v2 compatibility API) use any non empty string
 #define INFLUXDB_ORG "org name/id"
 // InfluxDB v2 bucket name (Use: InfluxDB UI -> Load Data -> Buckets)
 // InfluxDB 1.8+ (v2 compatibility API) use database name

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -67,13 +67,13 @@ class InfluxDBClient {
     // db - database name where to store or read data
     InfluxDBClient(const char *serverUrl, const char *db);
     // Creates InfluxDBClient instance for unsecured connection
-    // serverUrl - url of the InfluxDB 2 server (e.g. http://localhost:9999)
+    // serverUrl - url of the InfluxDB 2 server (e.g. http://localhost:8086)
     // org - name of the organization, which bucket belongs to    
     // bucket - name of the bucket to write data into
     // authToken - InfluxDB 2 authorization token
     InfluxDBClient(const char *serverUrl, const char *org, const char *bucket, const char *authToken);
     // Creates InfluxDBClient instance for secured connection
-    // serverUrl - url of the InfluxDB 2 server (e.g. https://localhost:9999)
+    // serverUrl - url of the InfluxDB 2 server (e.g. https://localhost:8086)
     // org - name of the organization, which bucket belongs to 
     // bucket - name of the bucket to write data into
     // authToken - InfluxDB 2 authorization token
@@ -104,7 +104,7 @@ class InfluxDBClient {
     //    client.setHTTPOptions(HTTPOptions().httpReadTimeout(20000)).
     void setHTTPOptions(const HTTPOptions &httpOptions);
     // Sets connection parameters for InfluxDB 2
-    // serverUrl - url of the InfluxDB 2 server (e.g. https//localhost:9999)
+    // serverUrl - url of the InfluxDB 2 server (e.g. https//localhost:8086)
     // org - name of the organization, which bucket belongs to 
     // bucket - name of the bucket to write data into
     // authToken - InfluxDB 2 authorization token


### PR DESCRIPTION
Closes #92 

An example port for InfluxDB 2 changed from 9999 to 8086. Some parts have been rephrased.
Also fixing misleading comment about empty org for v1 forward compatibility API