### PR TITLE
commented out unused decalaration

### DIFF
--- a/src/query/FluxParser.cpp
+++ b/src/query/FluxParser.cpp
@@ -201,7 +201,6 @@ readRow:
 }
 
 FluxDateTime *FluxQueryResult::convertRfc3339(String value, const char *type) {
-    // unused declaration FluxDateTime *ft = nullptr;
     tm t = {0,0,0,0,0,0,0,0,0};
     // has the time part
     int zet = value.indexOf('Z');

--- a/src/query/FluxParser.cpp
+++ b/src/query/FluxParser.cpp
@@ -201,7 +201,7 @@ readRow:
 }
 
 FluxDateTime *FluxQueryResult::convertRfc3339(String value, const char *type) {
-    FluxDateTime *ft = nullptr;
+    // unused declaration FluxDateTime *ft = nullptr;
     tm t = {0,0,0,0,0,0,0,0,0};
     // has the time part
     int zet = value.indexOf('Z');


### PR DESCRIPTION
Closes #

## Proposed Changes

Comment out/remove line 204 in FluxParser - unused declaration

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
