### PR TITLE
fix: allowing custom decimal places also for double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Documentation
 
 ### Fixes
+- [#108](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/108) - Added optional param for specifying decimal places of double.: `void Point::addField(String name, double value, int decimalPlaces = 2)`
 
 ## 3.4.0 [2020-10-02]
 ### Features

--- a/src/Point.h
+++ b/src/Point.h
@@ -41,7 +41,7 @@ class Point {
     void addTag(String name, String value);
     // Add field with various types
     void addField(String name, float value, int decimalPlaces = 2)         { if(!isnan(value)) putField(name, String(value, decimalPlaces)); }
-    void addField(String name, double value)        { if(!isnan(value)) putField(name, String(value)); }
+    void addField(String name, double value, int decimalPlaces = 2)        { if(!isnan(value)) putField(name, String(value, decimalPlaces)); }
     void addField(String name, char value)          { addField(name, String(value).c_str()); }
     void addField(String name, unsigned char value) { putField(name, String(value)+"i"); }
     void addField(String name, int value)           { putField(name, String(value)+"i"); }

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -9,6 +9,7 @@ var lastUserAgent = '';
 var chunked = false;
 var delay = 0;
 var permanentError = 0;
+const prefix = '';
 
 app.use (function(req, res, next) {
     var data='';
@@ -22,19 +23,19 @@ app.use (function(req, res, next) {
         next();
     });
 });
-app.get('/test/user-agent', (req,res) => {
+app.get(prefix + '/test/user-agent', (req,res) => {
     res.status(200).send(lastUserAgent);
 })
-app.get('/ready', (req,res) => {
+app.get(prefix + '/ready', (req,res) => {
     lastUserAgent = req.get('User-Agent');
     res.status(200).send("<html><body><h1>OK</h1></body></html>");
 })
-app.get('/health', (req,res) => {
+app.get(prefix + '/health', (req,res) => {
     lastUserAgent = req.get('User-Agent');
     res.status(200).send("<html><body><h1>OK</h1></body></html>");
 })
 
-app.get('/ping', (req,res) => {
+app.get(prefix + '/ping', (req,res) => {
     lastUserAgent = req.get('User-Agent');
     if(req.query['verbose'] == 'true') {
         res.status(200).send("<html><body><h1>OK</h1></body></html>");
@@ -42,12 +43,12 @@ app.get('/ping', (req,res) => {
         res.status(204).end();
     }
 })
-app.post('/log', (req,res) => {
+app.post(prefix + '/log', (req,res) => {
     console.log(req.body);
     res.status(204).end();
 })
 
-app.post('/api/v2/write', (req,res) => {
+app.post(prefix + '/api/v2/write', (req,res) => {
     chunked = false;
     if(checkWriteParams(req, res) && handleAuthentication(req, res)) {
         //console.log('Write');
@@ -132,7 +133,7 @@ app.post('/api/v2/write', (req,res) => {
     }
 })
 
-app.post('/write', (req,res) => {
+app.post(prefix + '/write', (req,res) => {
     if(checkWriteParamsV1(req, res) ) {
         var points = parsePoints(req.body);
         if(Array.isArray(points) && points.length > 0) {
@@ -170,7 +171,7 @@ app.post('/write', (req,res) => {
     }
 })
 
-app.post('/api/v2/delete', (req,res) => {
+app.post(prefix + '/api/v2/delete', (req,res) => {
     console.log('Deleteting points');
     pointsdb = [];
     res.status(204).end(); 
@@ -259,7 +260,7 @@ function sleep(milliseconds) {
     } while (currentDate - date < milliseconds);
   }
 
-app.post('/api/v2/query', (req,res) => {
+app.post(prefix+'/api/v2/query', (req,res) => {
     //console.log("Query with: " + req.body);
     if(checkQueryParams(req, res) && handleAuthentication(req, res)) {
         var queryObj = JSON.parse(req.body);

--- a/test/test.ino
+++ b/test/test.ino
@@ -7,10 +7,13 @@
 #define INFLUXDB_CLIENT_TESTING
 #include <InfluxDbClient.h>
 #include <InfluxDbCloud.h>
+
 #if defined(ESP32)
+#include <WiFi.h>
 String chipId = String((unsigned long)ESP.getEfuseMac());
 String deviceName = "ESP32";
 #elif defined(ESP8266)
+#include <ESP8266WiFi.h>
 String chipId = String(ESP.getChipId());
 String deviceName = "ESP8266";
 #endif


### PR DESCRIPTION
Closes #105

Added optional parameter for specifying decimal places of double: `void Point::addField(String name, double value, int decimalPlaces = 2)`


## Checklist


- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
