### PR TITLE
feat: retry strategy improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## 3.5.0 [in progress]
 ### Features
  - [#107](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/107) - Added possibility to set default tags. Use `WriteOptions::addDefaultTag()` to add a tag that will be added to each written point using the `writePoint()` function.
+ - [#109](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/109) - Retry strategy improvements:
+   - Added `canSendRequest()` function to check if retry strategy is applied
+   - Added `getRemaingRetryTime()` function to get wait time before another request (write/query) can be sent
+   - Removed applying retry wait time in case of network error
+   - Better explanatory error message when a request is about to be sent in the retry wait state
 
 ### Documentation
 

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -148,6 +148,12 @@ class InfluxDBClient {
     String getLastErrorMessage() const { return _lastErrorResponse; }
     // Returns server url
     String getServerUrl() const { return _serverUrl; }
+    // Check if it is possible to send write/query request to server. 
+    // Returns true if write or query can be send, or false, if server is overloaded and retry strategy is applied.
+    // Use getRemaingRetryTime() to get wait time in such case.
+    bool canSendRequest() { return getRemaingRetryTime() == 0; }
+    // Returns remaining wait time in seconds when retry strategy is applied.
+    uint32_t getRemaingRetryTime();
   protected:
     // Checks params and sets up security, if needed.
     // Returns true in case of success, otherwise false
@@ -155,7 +161,7 @@ class InfluxDBClient {
     // Sets request params
     void beforeRequest();
     // Handles response
-    void afterRequest(int expectedStatusCode);
+    void afterRequest(int expectedStatusCode, bool modifyLastConnStatus = true);
     // Cleans instances
     void clean();
   protected:

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -30,7 +30,7 @@
 #include <Arduino.h>
 
 #ifdef INFLUXDB_CLIENT_DEBUG_ENABLE
-# define INFLUXDB_CLIENT_DEBUG(fmt, ...) Serial.printf_P( (PGM_P)PSTR(fmt), ## __VA_ARGS__ )
+# define INFLUXDB_CLIENT_DEBUG(fmt, ...) Serial.printf("%.03f ",millis()/1000.0f);Serial.printf_P( (PGM_P)PSTR(fmt), ## __VA_ARGS__ )
 #else
 # define INFLUXDB_CLIENT_DEBUG(fmt, ...)
 #endif //INFLUXDB_CLIENT_DEBUG


### PR DESCRIPTION
Closes #96

 - Added `canSendRequest()` function to check if retry strategy is applied
 - Added `getRemaingRetryTime()` function to get wait time before another request (write/query) can be sent
 - Removed applying retry wait time in case of network error
 - Better explanatory error message when a request is about to be sent in the retry wait state

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
