### PR TITLE
fix: typo in menthod name: getRemaingRetryTime()->getRemainingRetryTime()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
-## 3.6.0 [in progress]
-### Features
-
+## 3.5.1 [in progress]
 ### Fixes
+- [#114](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/114) - Renamed `getRemaingRetryTime()`->`getRemainingRetryTime()`
 
 ## 3.5.0 [2020-10-30]
 ### Features
@@ -15,7 +14,7 @@
 
 ### Fixes
 - [#108](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/108) - Added optional param for specifying decimal places of double.: `void Point::addField(String name, double value, int decimalPlaces = 2)`
-- [#111](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/110) - Fixed blocked writing after another point reached max retry count (#110)
+- [#111](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/111) - Fixed blocked writing after another point reached max retry count (#110)
 
 ## 3.4.0 [2020-10-02]
 ### Features

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -424,7 +424,7 @@ bool InfluxDBClient::flushBuffer() {
     return flushBufferInternal(false);
 }
 
-uint32_t InfluxDBClient::getRemaingRetryTime() {
+uint32_t InfluxDBClient::getRemainingRetryTime() {
     uint32_t rem = 0;
     if(_lastRetryAfter > 0) {
         int32_t diff = _lastRetryAfter - (millis()-_lastRequestTime)/1000;
@@ -434,7 +434,7 @@ uint32_t InfluxDBClient::getRemaingRetryTime() {
 }
 
 bool InfluxDBClient::flushBufferInternal(bool flashOnlyFull) {
-    uint32_t rwt = getRemaingRetryTime();
+    uint32_t rwt = getRemainingRetryTime();
     if(rwt > 0) {
         INFLUXDB_CLIENT_DEBUG("[W] Cannot write yet, pause %ds, %ds yet\n", _lastRetryAfter, rwt);
         // retry after period didn't run out yet
@@ -485,7 +485,7 @@ bool InfluxDBClient::flushBufferInternal(bool flashOnlyFull) {
                             }
                         }
                     }
-                }
+                } 
                 INFLUXDB_CLIENT_DEBUG("[D] Leaving data in buffer for retry, retryInterval: %d\n",_lastRetryAfter);
                 // in case of retryable failure break loop
                 break;
@@ -596,7 +596,7 @@ static const char QueryDialect[] PROGMEM = "\
 }}";
 
 FluxQueryResult InfluxDBClient::query(String fluxQuery) {
-    uint32_t rwt = getRemaingRetryTime();
+    uint32_t rwt = getRemainingRetryTime();
     if(rwt > 0) {
         INFLUXDB_CLIENT_DEBUG("[W] Cannot query yet, pause %ds, %ds yet\n", _lastRetryAfter, rwt);
         // retry after period didn't run out yet

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -120,7 +120,7 @@ class InfluxDBClient {
     // Validates connection parameters by conecting to server
     // Returns true if successful, false in case of any error
     bool validateConnection();
-    // Writes record in InfluxDB line protocol format to write buffer
+    // Writes record in InfluxDB line protocol format to write buffer.
     // Returns true if successful, false in case of any error 
     bool writeRecord(String &record);
     // Writes record represented by Point to buffer
@@ -150,10 +150,10 @@ class InfluxDBClient {
     String getServerUrl() const { return _serverUrl; }
     // Check if it is possible to send write/query request to server. 
     // Returns true if write or query can be send, or false, if server is overloaded and retry strategy is applied.
-    // Use getRemaingRetryTime() to get wait time in such case.
-    bool canSendRequest() { return getRemaingRetryTime() == 0; }
+    // Use getRemainingRetryTime() to get wait time in such case.
+    bool canSendRequest() { return getRemainingRetryTime() == 0; }
     // Returns remaining wait time in seconds when retry strategy is applied.
-    uint32_t getRemaingRetryTime();
+    uint32_t getRemainingRetryTime();
   protected:
     // Checks params and sets up security, if needed.
     // Returns true in case of success, otherwise false


### PR DESCRIPTION
Fixing typo in method name:  renamed `InfluxDBClient::getRemaingRetryTime()`->`InfluxDBClient::getRemainingRetryTime()`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
