### PR TITLE
fix: Adding encoding URL params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
 - [#114](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/114) - Renamed `getRemaingRetryTime()`->`getRemainingRetryTime()`
 - [#115](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/115) - Restored writing capability after a connection failure
+- [#118](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/118) - Added escaping of URL params (org, bucker, V1 username and pass)
 
 ## 3.5.0 [2020-10-30]
 ### Features

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -233,25 +233,25 @@ void InfluxDBClient::setUrls() {
     if(_dbVersion == 2) {
         _writeUrl = _serverUrl;
         _writeUrl += "/api/v2/write?org=";
-        _writeUrl +=  _org ;
+        _writeUrl +=  urlEncode(_org.c_str());
         _writeUrl += "&bucket=";
-        _writeUrl += _bucket;
+        _writeUrl += urlEncode(_bucket.c_str());
         INFLUXDB_CLIENT_DEBUG("  writeUrl: %s\n", _writeUrl.c_str());
         _queryUrl = _serverUrl;
         _queryUrl += "/api/v2/query?org=";
-        _queryUrl +=  _org;
+        _queryUrl +=  urlEncode(_org.c_str());
         INFLUXDB_CLIENT_DEBUG("  queryUrl: %s\n", _queryUrl.c_str());
     } else {
         _writeUrl = _serverUrl;
         _writeUrl += "/write?db=";
-        _writeUrl += _bucket;
+        _writeUrl += urlEncode(_bucket.c_str());
         _queryUrl = _serverUrl;
         _queryUrl += "/api/v2/query";
         if(_user.length() > 0 && _password.length() > 0) {
             String auth = "&u=";
-            auth += _user;
+            auth += urlEncode(_user.c_str());
             auth += "&p=";
-            auth += _password;
+            auth += urlEncode(_password.c_str());
             _writeUrl += auth;  
             _queryUrl += "?";
             _queryUrl += auth;

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -118,3 +118,32 @@ String escapeValue(const char *value) {
     }
     return ret;
 }
+
+
+static char invalidChars[] = "$&+,/:;=?@ <>#%{}|\\^~[]`";
+
+static char hex_digit(char c) {
+    return "0123456789ABCDEF"[c & 0x0F];
+}
+
+String urlEncode(const char* src) {  
+    int n=0;
+    char c,*s = (char *)src;
+    while (c = *s++) {
+        if(strchr(invalidChars, c)) {
+            n++;
+        } 
+    }
+    String ret;
+    ret.reserve(strlen(src)+2*n+1);
+    s = (char *)src;
+    while (c = *s++) {  
+       if (strchr(invalidChars,c)) {
+           ret += '%';
+           ret += hex_digit(c >> 4);
+           ret += hex_digit(c);
+      }
+      else ret += c;
+   }
+   return ret;
+}

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -46,6 +46,8 @@ String escapeKey(String key, bool escapeEqual = true);
 
 // Escape invalid chars in field value
 String escapeValue(const char *value);
+// Encode URL string for invalid chars
+String urlEncode(const char* src);
 
 
 #endif //_INFLUXDB_CLIENT_HELPERS_H

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -73,6 +73,7 @@ void Test::run() {
     testOptions();
     testPoint();
     testEcaping();
+    testUrlEncode();
     testFluxTypes();
     testFluxParserEmpty();
     testFluxParserSingleTable();
@@ -104,69 +105,69 @@ void Test::run() {
 }
 
 void Test::testOptions() {
-        TEST_INIT("testOptions");
-        WriteOptions defWO;
-        TEST_ASSERT(defWO._writePrecision == WritePrecision::NoTime);
-        TEST_ASSERT(defWO._batchSize == 1);
-        TEST_ASSERT(defWO._bufferSize == 5);
-        TEST_ASSERT(defWO._flushInterval == 60);
-        TEST_ASSERT(defWO._retryInterval == 5);
-        TEST_ASSERT(defWO._maxRetryInterval == 300);
-        TEST_ASSERT(defWO._maxRetryAttempts == 3);
-        TEST_ASSERT(defWO._defaultTags.length() == 0);
+    TEST_INIT("testOptions");
+    WriteOptions defWO;
+    TEST_ASSERT(defWO._writePrecision == WritePrecision::NoTime);
+    TEST_ASSERT(defWO._batchSize == 1);
+    TEST_ASSERT(defWO._bufferSize == 5);
+    TEST_ASSERT(defWO._flushInterval == 60);
+    TEST_ASSERT(defWO._retryInterval == 5);
+    TEST_ASSERT(defWO._maxRetryInterval == 300);
+    TEST_ASSERT(defWO._maxRetryAttempts == 3);
+    TEST_ASSERT(defWO._defaultTags.length() == 0);
 
-        defWO = WriteOptions().writePrecision(WritePrecision::NS).batchSize(10).bufferSize(20).flushInterval(120).retryInterval(1).maxRetryInterval(20).maxRetryAttempts(5).addDefaultTag("tag1","val1").addDefaultTag("tag2","val2");
-        TEST_ASSERT(defWO._writePrecision == WritePrecision::NS);
-        TEST_ASSERT(defWO._batchSize == 10);
-        TEST_ASSERT(defWO._bufferSize == 20);
-        TEST_ASSERT(defWO._flushInterval == 120);
-        TEST_ASSERT(defWO._retryInterval == 1);
-        TEST_ASSERT(defWO._maxRetryInterval == 20);
-        TEST_ASSERT(defWO._maxRetryAttempts == 5);
-        TEST_ASSERT(defWO._defaultTags == "tag1=val1,tag2=val2");
+    defWO = WriteOptions().writePrecision(WritePrecision::NS).batchSize(10).bufferSize(20).flushInterval(120).retryInterval(1).maxRetryInterval(20).maxRetryAttempts(5).addDefaultTag("tag1","val1").addDefaultTag("tag2","val2");
+    TEST_ASSERT(defWO._writePrecision == WritePrecision::NS);
+    TEST_ASSERT(defWO._batchSize == 10);
+    TEST_ASSERT(defWO._bufferSize == 20);
+    TEST_ASSERT(defWO._flushInterval == 120);
+    TEST_ASSERT(defWO._retryInterval == 1);
+    TEST_ASSERT(defWO._maxRetryInterval == 20);
+    TEST_ASSERT(defWO._maxRetryAttempts == 5);
+    TEST_ASSERT(defWO._defaultTags == "tag1=val1,tag2=val2");
 
-        HTTPOptions defHO;
-        TEST_ASSERT(!defHO._connectionReuse);
-        TEST_ASSERT(defHO._httpReadTimeout == 5000);
+    HTTPOptions defHO;
+    TEST_ASSERT(!defHO._connectionReuse);
+    TEST_ASSERT(defHO._httpReadTimeout == 5000);
 
-        defHO = HTTPOptions().connectionReuse(true).httpReadTimeout(20000);
-        TEST_ASSERT(defHO._connectionReuse);
-        TEST_ASSERT(defHO._httpReadTimeout == 20000);
+    defHO = HTTPOptions().connectionReuse(true).httpReadTimeout(20000);
+    TEST_ASSERT(defHO._connectionReuse);
+    TEST_ASSERT(defHO._httpReadTimeout == 20000);
 
-        InfluxDBClient c;
-        TEST_ASSERT(c._writeOptions._writePrecision == WritePrecision::NoTime);
-        TEST_ASSERT(c._writeOptions._batchSize == 1);
-        TEST_ASSERT(c._writeOptions._bufferSize == 5);
-        TEST_ASSERT(c._writeOptions._flushInterval == 60);
-        TEST_ASSERT(c._writeOptions._retryInterval == 5);
-        TEST_ASSERT(c._writeOptions._maxRetryAttempts == 3);
-        TEST_ASSERT(c._writeOptions._maxRetryInterval == 300);
-        TEST_ASSERT(!c._httpOptions._connectionReuse);
-        TEST_ASSERT(c._httpOptions._httpReadTimeout == 5000);
+    InfluxDBClient c;
+    TEST_ASSERT(c._writeOptions._writePrecision == WritePrecision::NoTime);
+    TEST_ASSERT(c._writeOptions._batchSize == 1);
+    TEST_ASSERT(c._writeOptions._bufferSize == 5);
+    TEST_ASSERT(c._writeOptions._flushInterval == 60);
+    TEST_ASSERT(c._writeOptions._retryInterval == 5);
+    TEST_ASSERT(c._writeOptions._maxRetryAttempts == 3);
+    TEST_ASSERT(c._writeOptions._maxRetryInterval == 300);
+    TEST_ASSERT(!c._httpOptions._connectionReuse);
+    TEST_ASSERT(c._httpOptions._httpReadTimeout == 5000);
 
-        c.setWriteOptions(defWO);
-        TEST_ASSERT(c._writeOptions._writePrecision == WritePrecision::NS);
-        TEST_ASSERT(c._writeOptions._batchSize == 10);
-        TEST_ASSERT(c._writeOptions._bufferSize == 20);
-        TEST_ASSERT(c._writeOptions._flushInterval == 120);
-        TEST_ASSERT(c._writeOptions._retryInterval == 1);
-        TEST_ASSERT(c._writeOptions._maxRetryAttempts == 5);
-        TEST_ASSERT(c._writeOptions._maxRetryInterval == 20);
+    c.setWriteOptions(defWO);
+    TEST_ASSERT(c._writeOptions._writePrecision == WritePrecision::NS);
+    TEST_ASSERT(c._writeOptions._batchSize == 10);
+    TEST_ASSERT(c._writeOptions._bufferSize == 20);
+    TEST_ASSERT(c._writeOptions._flushInterval == 120);
+    TEST_ASSERT(c._writeOptions._retryInterval == 1);
+    TEST_ASSERT(c._writeOptions._maxRetryAttempts == 5);
+    TEST_ASSERT(c._writeOptions._maxRetryInterval == 20);
 
-        c.setHTTPOptions(defHO);
-        TEST_ASSERT(c._httpOptions._connectionReuse);
-        TEST_ASSERT(c._httpOptions._httpReadTimeout == 20000);
+    c.setHTTPOptions(defHO);
+    TEST_ASSERT(c._httpOptions._connectionReuse);
+    TEST_ASSERT(c._httpOptions._httpReadTimeout == 20000);
 
-        c.setWriteOptions(WritePrecision::MS, 15, 14, 70, false);
-        TEST_ASSERT(c._writeOptions._writePrecision == WritePrecision::MS);
-        TEST_ASSERT(c._writeOptions._batchSize == 15);
-        TEST_ASSERTM(c._writeOptions._bufferSize == 30, String(c._writeOptions._bufferSize));
-        TEST_ASSERT(c._writeOptions._flushInterval == 70);
-        TEST_ASSERT(!c._httpOptions._connectionReuse);
-        TEST_ASSERT(c._httpOptions._httpReadTimeout == 20000);
+    c.setWriteOptions(WritePrecision::MS, 15, 14, 70, false);
+    TEST_ASSERT(c._writeOptions._writePrecision == WritePrecision::MS);
+    TEST_ASSERT(c._writeOptions._batchSize == 15);
+    TEST_ASSERTM(c._writeOptions._bufferSize == 30, String(c._writeOptions._bufferSize));
+    TEST_ASSERT(c._writeOptions._flushInterval == 70);
+    TEST_ASSERT(!c._httpOptions._connectionReuse);
+    TEST_ASSERT(c._httpOptions._httpReadTimeout == 20000);
 
-        TEST_END();
-    }
+    TEST_END();
+}
 
 
 void Test::testEcaping() {
@@ -433,7 +434,7 @@ void Test::testHTTPReadTimeout() {
     InfluxDBClient client(Test::apiUrl, Test::orgName, Test::bucketName, Test::token);
     waitServer(Test::managementUrl, true);
     TEST_ASSERT(client.validateConnection());
-    //set server delay for 6s (client has default timeout 5s)
+    //set server delay on query for 6s (client has default timeout 5s)
     String rec = "a,direction=timeout,timeout=6 a=1";
     TEST_ASSERT(client.writeRecord(rec));
     rec = "a,tag=a, a=1i";
@@ -449,7 +450,7 @@ void Test::testHTTPReadTimeout() {
     TEST_ASSERT(client.writeRecord(rec));
     q = client.query(query);
     // should be ok
-    TEST_ASSERT(q.next());
+    TEST_ASSERTM(q.next(), q.getError());
     TEST_ASSERT(!q.next());
     TEST_ASSERTM(q.getError() == "", q.getError());
     q.close();
@@ -1089,10 +1090,11 @@ void Test::testTimestamp() {
 }
 
 void Test::testV1() {
-
     TEST_INIT("testV1");
-    InfluxDBClient client(Test::apiUrl, Test::dbName);
+    InfluxDBClient client;
 
+    client.setConnectionParamsV1(Test::apiUrl, Test::dbName, "user","my secret password");
+    waitServer(Test::managementUrl, true);
     TEST_ASSERTM(client.validateConnection(), client.getLastErrorMessage());
     //test with no batching
     for (int i = 0; i < 20; i++) {
@@ -1870,6 +1872,14 @@ void Test::testDefaultTags() {
 
     TEST_END();
     deleteAll(Test::apiUrl);
+}
+
+void Test::testUrlEncode() {
+    TEST_INIT("testUrlEncode");
+    String res = "my%20%5Bsecret%5D%20pass%3A%2F%5Cw%60o%5Er%25d";
+    String urlEnc = urlEncode("my [secret] pass:/\\w`o^r%d");
+    TEST_ASSERTM(res == urlEnc, urlEnc);
+    TEST_END();
 }
 
 void Test::setServerUrl(InfluxDBClient &client, String serverUrl) {

--- a/test/Test.h
+++ b/test/Test.h
@@ -75,6 +75,7 @@ private: // tests
     static void testRetriesOnServerOverload();
     static void testRetryInterval();
     static void testDefaultTags();
+    static void testUrlEncode();
 };
 
 bool testAssertm(int line, bool state,String message);

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -427,14 +427,18 @@ function checkWriteParams(req, res) {
 const AllowedPrecisionsV1 = ['ns','u','ms','s'];
 function checkWriteParamsV1(req, res) {
     var db = req.query['db'];
+    var user = req.query['u'];
+    var pass = req.query['p'];
     var precision = req.query['precision'];
     if(db != 'my-db') {
         res.status(404).send(`{"code":"not found","message":"database \"${db}\" not found"}`);
         return false;
     } else if(typeof precision !== 'undefined' && AllowedPrecisionsV1.indexOf(precision)==-1) {
-        res.status(400).send(`{"code":"bad request ","message":"precision \"${precision}\" is not valid"}`);
+        res.status(400).send(`precision \"${precision}\" is not valid`);
         return false;
-    }else {
+    } else if (user !== 'user' && pass != 'my secret pass') {
+        res.status(401).send("unauthorized")
+    } else {
         return true;
     }
 }


### PR DESCRIPTION
Closes #116

## Proposed Changes

Added escaping of URL params (org, bucker, V1 username and pass)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
