### PR TITLE
fix: leaking WiFiClient instance when repeated setting of connection params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 3.6.1 [in progress]
+### Features
+### Fixes
+- [#121](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/121) - Fixed compile error in case of warning is treated as an error
+- [#122](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/122) - Deleting WiFiClient instance to avoid memory leaking when the InfluxDBClient is reinitialized
+### Doc
+- [#120](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/120) - Improved language wording in the Readme
+
 ## 3.6.0 [2020-11-10]
 ### Features
 - [#117](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/117) - Added `InfluxDBClient::pointToLineProtocol(const Point& point)` for simple creation of InfluxDB line-protocol string with respect to default tags
@@ -30,7 +38,7 @@
     - Added possibility to set HTTP response read timeout (part of the `HTTPOptions`).
     - Method `InfluxDBClient::void setWriteOptions(WritePrecision precision, uint16_t batchSize = 1, uint16_t bufferSize = 5, uint16_t flushInterval = 60, bool preserveConnection = true)` is deprecated and it will be removed in the next release.
  - [#93](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/93) - Write logic improvements 
-   - Retry on failure logic unification with other InfluxDB clients (exponencial retry, max retry count 3, max retry interval)
+   - Retry on failure logic unification with other InfluxDB clients (exponential retry, max retry count 3, max retry interval)
    - Better write buffer memory management
 
 ### Documentation
@@ -43,7 +51,7 @@
 
 ## Version 3.3.0 (2020-07-07)
  - [NEW] Added possibility skip server certification validation (`setInsecure()` method)
- - [NEW] Added possibility to query flux on secured InfuxDB 1.8 using V1 approach
+ - [NEW] Added possibility to query flux on secured InfluxDB 1.8 using V1 approach
  - [NEW] `validateConnection()` can be used also for the [forward compatibility](https://docs.influxdata.com/influxdb/latest/tools/api/#influxdb-2-0-api-compatibility-endpoints) connection to InfluxDB 1.8
  - [FIX] More precice default timestamp generating, up to microseconds
  - [FIX] Debug compilation error

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -219,7 +219,7 @@ class InfluxDBClient {
     // Server reponse or library error message for last failed request
     String _lastErrorResponse;
     // Underlying HTTPClient instance 
-    HTTPClient _httpClient;
+    HTTPClient *_httpClient = nullptr;
     // Underlying connection object 
     WiFiClient *_wifiClient = nullptr;
     // Certificate info

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -460,15 +460,22 @@ void Test::testHTTPReadTimeout() {
 }
 
 void Test::testRepeatedInit() {
+    // test for validation repeated re-init and not leaking wificlient
     TEST_INIT("testRepeatedInit");
-    InfluxDBClient client;
-    //waitServer(Test::managementUrl, true);
-    for(int i = 0; i<20;i++) {
-        client.setConnectionParams(Test::apiUrl, Test::orgName, Test::bucketName, Test::token);
-        TEST_ASSERT(client.validateConnection());
-    }
+    
+    waitServer(Test::managementUrl, true);
+    uint32_t startRAM = ESP.getFreeHeap();
+    do {
+        InfluxDBClient client;
+        for(int i = 0; i<20;i++) {
+            client.setConnectionParams(Test::apiUrl, Test::orgName, Test::bucketName, Test::token);
+            TEST_ASSERT(client.validateConnection());
+        }
+    } while(0);
+    uint32_t endRAM = ESP.getFreeHeap();
+    long diff = endRAM-startRAM;
+    TEST_ASSERTM(diff>-100,String(diff));
     TEST_END();
-    deleteAll(Test::apiUrl);
 }
 
 void Test::testRetryOnFailedConnection() {
@@ -865,7 +872,7 @@ void Test::testRetriesOnServerOverload() {
             }
         }
         delete p;
-        delay(164);
+        delay(162);
     }
     TEST_ASSERT(!client.isBufferEmpty());
     TEST_ASSERT(client.flushBuffer());

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -87,6 +87,7 @@ void Test::run() {
     testFluxParserErrorInRow();
     testBasicFunction();
     testInit();
+    testRepeatedInit();
     testV1();
     testUserAgent();
     testHTTPReadTimeout();
@@ -454,6 +455,18 @@ void Test::testHTTPReadTimeout() {
     TEST_ASSERT(!q.next());
     TEST_ASSERTM(q.getError() == "", q.getError());
     q.close();
+    TEST_END();
+    deleteAll(Test::apiUrl);
+}
+
+void Test::testRepeatedInit() {
+    TEST_INIT("testRepeatedInit");
+    InfluxDBClient client;
+    //waitServer(Test::managementUrl, true);
+    for(int i = 0; i<20;i++) {
+        client.setConnectionParams(Test::apiUrl, Test::orgName, Test::bucketName, Test::token);
+        TEST_ASSERT(client.validateConnection());
+    }
     TEST_END();
     deleteAll(Test::apiUrl);
 }

--- a/test/Test.h
+++ b/test/Test.h
@@ -76,6 +76,7 @@ private: // tests
     static void testRetryInterval();
     static void testDefaultTags();
     static void testUrlEncode();
+    static void testRepeatedInit();
 };
 
 bool testAssertm(int line, bool state,String message);

--- a/test/TestSupport.cpp
+++ b/test/TestSupport.cpp
@@ -34,6 +34,7 @@
 
 #include "TestSupport.h"
 
+static HTTPClient httpClient;
 
 void printFreeHeap() {
   Serial.print("[TD] Free heap: ");  
@@ -41,28 +42,26 @@ void printFreeHeap() {
 }
 
 int httpPOST(String url, String mess) {
-  HTTPClient http;
-  http.setReuse(false);
+  httpClient.setReuse(false);
   int code = 0;
-  if(http.begin(url)) {
-    code = http.POST(mess);
-    http.end();
+  if(httpClient.begin(url)) {
+    code = httpClient.POST(mess);
+    httpClient.end();
   }
   return code;
 }
 
 int httpGET(String url) {
-  HTTPClient http;
-  http.setReuse(false);
+  httpClient.setReuse(false);
   int code = 0;
-  if(http.begin(url)) {
-    code = http.GET();
+  if(httpClient.begin(url)) {
+    code = httpClient.GET();
     if(code != 204) {
        //Serial.print("[TD] ");
        //String res = http.getString();
        //Serial.println(res);
     }
-    http.end();
+    httpClient.end();
   }
   return code;
 }

--- a/test/test.ino
+++ b/test/test.ino
@@ -2,7 +2,7 @@
  *  Sketch for running InfluxDBClient tests.
  *  For compiling in VSCode add path to workspace ("${workspaceFolder}\\**")
  *  Most of the tests require running mock server: cd test/server & node server.js. It will print ip adresses of available network interfaces.
- *  Modify INFLUXDB_CLIENT_MANAGEMENT_URL and INFLUXDB_CLIENT_TESTING_URL macros to set the correct mock server address.
+ *  Modify INFLUXDB_CLIENT_TESTING_SERVER_HOST to set the correct mock server address.
  * 
  */
 
@@ -15,8 +15,7 @@
 #include <ESP8266WiFi.h>
 #endif
 
-#define INFLUXDB_CLIENT_MANAGEMENT_URL "http://192.168.88.142:998"
-#define INFLUXDB_CLIENT_TESTING_URL "http://192.168.88.142:999"
+#define INFLUXDB_CLIENT_TESTING_SERVER_HOST "192.168.88.142"
 #define INFLUXDB_CLIENT_TESTING_ORG "my-org"
 #define INFLUXDB_CLIENT_TESTING_BUC "my-bucket"
 #define INFLUXDB_CLIENT_TESTING_DB "my-db"
@@ -25,6 +24,10 @@
 #define INFLUXDB_CLIENT_TESTING_PASS "password"
 
 #include "customSettings.h"
+
+#define INFLUXDB_CLIENT_MANAGEMENT_URL "http://" INFLUXDB_CLIENT_TESTING_SERVER_HOST ":998"
+#define INFLUXDB_CLIENT_TESTING_URL "http://" INFLUXDB_CLIENT_TESTING_SERVER_HOST ":999"
+
 #include "TestSupport.h"
 #include "Test.h"
 


### PR DESCRIPTION
## Proposed Changes

Added proper cleaning of WiFiClient instance.
Added other PRs to the changelog

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
