### PR TITLE
feat: add user and password to validation ping

### DIFF
--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -252,12 +252,18 @@ void InfluxDBClient::setUrls() {
         _queryUrl += "/api/v2/query?org=";
         _queryUrl +=  urlEncode(_org.c_str());
         INFLUXDB_CLIENT_DEBUG("[D]  queryUrl: %s\n", _queryUrl.c_str());
+        _validateUrl = _serverUrl;
+        _validateUrl += "/health";
+        INFLUXDB_CLIENT_DEBUG("[D]  validateUrl: %s\n", _validateUrl.c_str());
     } else {
         _writeUrl = _serverUrl;
         _writeUrl += "/write?db=";
         _writeUrl += urlEncode(_bucket.c_str());
         _queryUrl = _serverUrl;
         _queryUrl += "/api/v2/query";
+        // on version 1.x /ping will by default return status code 204, without verbose
+        _validateUrl = _serverUrl;
+        _validateUrl += "/ping?verbose=true";
         if(_user.length() > 0 && _password.length() > 0) {
             String auth = "&u=";
             auth += urlEncode(_user.c_str());
@@ -266,9 +272,11 @@ void InfluxDBClient::setUrls() {
             _writeUrl += auth;  
             _queryUrl += "?";
             _queryUrl += auth;
+            _validateUrl += auth;
         }
         INFLUXDB_CLIENT_DEBUG("[D]  writeUrl: %s\n", _writeUrl.c_str());
         INFLUXDB_CLIENT_DEBUG("[D]  queryUrl: %s\n", _queryUrl.c_str());
+        INFLUXDB_CLIENT_DEBUG("[D]  validateUrl: %s\n", _validateUrl.c_str());
     }
     if(_writeOptions._writePrecision != WritePrecision::NoTime) {
         _writeUrl += "&precision=";
@@ -543,11 +551,9 @@ bool InfluxDBClient::validateConnection() {
         _lastErrorResponse = FPSTR(UninitializedMessage);
         return false;
     }
-    // on version 1.x /ping will by default return status code 204, without verbose
-    String url = _serverUrl + (_dbVersion==2?"/health":"/ping?verbose=true");
-    INFLUXDB_CLIENT_DEBUG("[D] Validating connection to %s\n", url.c_str());
+    INFLUXDB_CLIENT_DEBUG("[D] Validating connection to %s\n", _serverUrl.c_str());
 
-    if(!_httpClient->begin(*_wifiClient, url)) {
+    if(!_httpClient->begin(*_wifiClient, _validateUrl)) {
         INFLUXDB_CLIENT_DEBUG("[E] begin failed\n");
         return false;
     }

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -195,6 +195,8 @@ class InfluxDBClient {
     String _writeUrl;
     // Cached full query url
     String _queryUrl;
+    // Cached full validation url
+    String _validateUrl;
     // Points buffer
     Batch **_writeBuffer = nullptr;
     // Batch buffer size

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -195,8 +195,6 @@ class InfluxDBClient {
     String _writeUrl;
     // Cached full query url
     String _queryUrl;
-    // Cached full validation url
-    String _validateUrl;
     // Points buffer
     Batch **_writeBuffer = nullptr;
     // Batch buffer size


### PR DESCRIPTION
## Proposed Changes

Add user and password to the validation ping in validateConnection().
This is needed when "ping-auth-enabled" is set to true in influxdb 1.x.
When "ping-auth-enabled" is set to false the validation succeedes even when user and password are set.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
