### PR TITLE
fix: secure doc, demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 3.x.x [in progress]
+### Documentation
+ - [#134](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/134):
+   - Added untrusted connection (skipping certificate validation) info to Readme
+   - `SecureWrite` and `SecureBatchWrite` demos enhanced with example about using untrusted connection
+   - Various fixes of typos
+
 ## 3.7.0 [2020-12-24]
 ### Features
  - [#125](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/124) - Added credentials to the InfluxDB 1.x validation endpoint (/ping). To leverage this, [enable ping authentication](https://docs.influxdata.com/influxdb/v1.8/administration/config/#ping-auth-enabled-false) 
@@ -40,7 +47,7 @@
 
 ## 3.4.0 [2020-10-02]
 ### Features
- - [#89](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/89) - ESP8266 only - Added Max Fragment Length Negotiation for TLS communicaton to reduce memory allocation. If server supports MFLN, it saves ~10kB. Standalone InfluxDB OSS server doesn't support MFLN, Cloud yes. To leverage MFLN for standalone OSS, a reverse proxy needs to be used. 
+ - [#89](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/89) - ESP8266 only - Added Max Fragment Length Negotiation for TLS communication to reduce memory allocation. If server supports MFLN, it saves ~10kB. Standalone InfluxDB OSS server doesn't support MFLN, Cloud yes. To leverage MFLN for standalone OSS, a reverse proxy needs to be used. 
  - [#91](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/91) - Improved API for settings of write and HTTP options:
     - Introduced `WriteOptions` to wrap the write related options (write precision, batch-size, etc). It offers fluent style API allowing to change only the required options. `InfluxDBClient` has overloaded `setWriteOptions(const WriteOptions& writeOptions)` method.
     - Introduced `HTTPOptions` to wrap the HTTP related options (e.g. reusing connection). It offers fluent style API allowing to change only the required options. `InfluxDBClient` has `setHTTPOptions(const HTTPOptions& httpOptions)` method.
@@ -62,7 +69,7 @@
  - [NEW] Added possibility skip server certification validation (`setInsecure()` method)
  - [NEW] Added possibility to query flux on secured InfluxDB 1.8 using V1 approach
  - [NEW] `validateConnection()` can be used also for the [forward compatibility](https://docs.influxdata.com/influxdb/latest/tools/api/#influxdb-2-0-api-compatibility-endpoints) connection to InfluxDB 1.8
- - [FIX] More precice default timestamp generating, up to microseconds
+ - [FIX] More precise default timestamp generating, up to microseconds
  - [FIX] Debug compilation error
  - [FIX] SecureBatchWrite compile error
  
@@ -91,6 +98,6 @@
 ## Version 3.0.0 (2020-02-11)
  - New API with similar keywords as other official InfluxDB clients
  - Richer set of data types for fields and timestamp methods
- - Advanced features, such as implicit batching, automatic retrying on server backpressure and connection failure, along with secured communication over TLS supported for both devices and authentication
+ - Advanced features, such as implicit batching, automatic retrying on server back-pressure and connection failure, along with secured communication over TLS supported for both devices and authentication
  - Special characters escaping
  - Backward support for original API of V1/V2

--- a/examples/BasicWrite/BasicWrite.ino
+++ b/examples/BasicWrite/BasicWrite.ino
@@ -53,7 +53,7 @@ void setup() {
   wifiMulti.addAP(WIFI_SSID, WIFI_PASSWORD);
   while (wifiMulti.run() != WL_CONNECTED) {
     Serial.print(".");
-    delay(100);
+    delay(500);
   }
   Serial.println();
 
@@ -83,8 +83,9 @@ void loop() {
   Serial.print("Writing: ");
   Serial.println(client.pointToLineProtocol(sensor));
   // If no Wifi signal, try to reconnect it
-  if ((WiFi.RSSI() == 0) && (wifiMulti.run() != WL_CONNECTED))
+  if (wifiMulti.run() != WL_CONNECTED) {
     Serial.println("Wifi connection lost");
+  }
   // Write point
   if (!client.writePoint(sensor)) {
     Serial.print("InfluxDB write failed: ");

--- a/examples/QueryAggregated/QueryAggregated.ino
+++ b/examples/QueryAggregated/QueryAggregated.ino
@@ -1,7 +1,7 @@
 /**
  * QueryAggregated Example code for InfluxDBClient library for Arduino.
  * 
- * This example demonstrates querying basic aggreagated statistic parameters of WiFi signal level measured and stored in BasicWrite and SecureWrite examples.
+ * This example demonstrates querying basic aggregated statistic parameters of WiFi signal level measured and stored in BasicWrite and SecureWrite examples.
  * 
  * Demonstrates connection to any InfluxDB instance accesible via:
  *  - unsecured http://...

--- a/examples/QueryTable/QueryTable.ino
+++ b/examples/QueryTable/QueryTable.ino
@@ -119,7 +119,7 @@ void loop() {
     Serial.print("  ");
     // Print values of the row
     for(FluxValue &val: result.getValues()) {
-      // Check wheter the value is null
+      // Check whether the value is null
       if(!val.isNull()) {
         // Use raw string, unconverted value
         Serial.print(val.getRawValue());

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -131,7 +131,9 @@ bool InfluxDBClient::init() {
     if(https) {
 #if defined(ESP8266)         
         BearSSL::WiFiClientSecure *wifiClientSec = new BearSSL::WiFiClientSecure;
-        if(_certInfo && strlen_P(_certInfo) > 0) {
+        if (_insecure) {
+            wifiClientSec->setInsecure();
+        } else if(_certInfo && strlen_P(_certInfo) > 0) {
             if(strlen_P(_certInfo) > 60 ) { //differentiate fingerprint and cert
                 _cert = new BearSSL::X509List(_certInfo); 
                 wifiClientSec->setTrustAnchors(_cert);
@@ -139,13 +141,11 @@ bool InfluxDBClient::init() {
                 wifiClientSec->setFingerprint(_certInfo);
             }
         }
-        if (_insecure) {
-            wifiClientSec->setInsecure();
-        }
+        
         checkMFLN(wifiClientSec, _serverUrl);
 #elif defined(ESP32)
         WiFiClientSecure *wifiClientSec = new WiFiClientSecure;  
-        if(_certInfo && strlen_P(_certInfo) > 0) { 
+        if(!_insecure && _certInfo && strlen_P(_certInfo) > 0) { 
               wifiClientSec->setCACert(_certInfo);
          }
 #endif    

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -81,8 +81,8 @@ class InfluxDBClient {
     InfluxDBClient(const char *serverUrl, const char *org, const char *bucket, const char *authToken, const char *certInfo);
     // Clears instance.
     ~InfluxDBClient();
-    // Allows insecure connection. setInsecure must be called before calling any method initiating a connection to server.
-    // Works only on ESP8266. ESP32 allows unsecured connections by default (status for latest 1.0.4 ESP32 Arduino SDK).
+    // Allows insecure connection by skiping server certificate validation. 
+    // setInsecure must be called before calling any method initiating a connection to server.
     void setInsecure(bool value);
     // precision - timestamp precision of written data
     // batchSize - number of points that will be written to the databases at once. Default 1 - writes immediately


### PR DESCRIPTION
Closes #131

## Proposed Changes
 - Added untrusted connection (skipping certificate validation) info to Readme
 - `SecureWrite` and `SecureBatchWrite` demos enhanced with example about using untrusted connection
 - Various fixes of typos

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
