### PR TITLE
feat: setInsecure also for ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## 3.7.1 [in progress]
+### Features
+ - [#143](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/143) - `InfluxDBClient::setInsecure` now works also for ESP32. Requires Arduino ESP32 SDK 1.0.5 or higher
+
 ### Documentation
  - [#134](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/134):
    - Added untrusted connection (skipping certificate validation) info to Readme

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKE
 
 void setup() {
     // Set insecure connection to skip server certificate validation 
-    client.setInsecure(true);
+    client.setInsecure();
 }
 ```
 

--- a/examples/SecureBatchWrite/SecureBatchWrite.ino
+++ b/examples/SecureBatchWrite/SecureBatchWrite.ino
@@ -82,7 +82,7 @@ void setup() {
   sensorStatus.addTag("SSID", WiFi.SSID());
 
   // Alternatively, set insecure connection to skip server certificate validation 
-  //client.setInsecure(true);
+  //client.setInsecure();
 
   // Accurate time is necessary for certificate validation and writing in batches
   // Syncing progress and the time will be printed to Serial.

--- a/examples/SecureWrite/SecureWrite.ino
+++ b/examples/SecureWrite/SecureWrite.ino
@@ -72,7 +72,7 @@ void setup() {
   sensor.addTag("SSID", WiFi.SSID());
 
   // Alternatively, set insecure connection to skip server certificate validation 
-  //client.setInsecure(true);
+  //client.setInsecure();
 
   // Accurate time is necessary for certificate validation and writing in batches
   // For the fastest time sync find NTP servers in your area: https://www.pool.ntp.org/zone/

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -141,13 +141,17 @@ bool InfluxDBClient::init() {
                 wifiClientSec->setFingerprint(_certInfo);
             }
         }
-        
         checkMFLN(wifiClientSec, _serverUrl);
 #elif defined(ESP32)
         WiFiClientSecure *wifiClientSec = new WiFiClientSecure;  
-        if(!_insecure && _certInfo && strlen_P(_certInfo) > 0) { 
-              wifiClientSec->setCACert(_certInfo);
-         }
+        if (_insecure) {
+#ifndef ARDUINO_ESP32_RELEASE_1_0_4
+            // This works only in ESP32 SDK 1.0.5 and higher
+            wifiClientSec->setInsecure();
+#endif            
+        } else if(_certInfo && strlen_P(_certInfo) > 0) { 
+           wifiClientSec->setCACert(_certInfo);
+        }
 #endif    
         _wifiClient = wifiClientSec;
     } else {

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -83,7 +83,7 @@ class InfluxDBClient {
     ~InfluxDBClient();
     // Allows insecure connection by skiping server certificate validation. 
     // setInsecure must be called before calling any method initiating a connection to server.
-    void setInsecure(bool value);
+    void setInsecure(bool value = true);
     // precision - timestamp precision of written data
     // batchSize - number of points that will be written to the databases at once. Default 1 - writes immediately
     // bufferSize - maximum size of Points buffer. Buffer contains new data that will be written to the database


### PR DESCRIPTION
Closes #141 

## Proposed Changes

Adding call to WifiClientSecure::setInsesure() also for ESP32.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
