### PR TITLE
fix: setting httpReadTimeout as connect timeout for HTTP connection for ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 3.8.1 [in progress]
+### Fixes
+ - [#150](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/150) - `HTTPOptions::httpReadTimeout` is also set as the connect timeout for HTTP connection on ESP32. It doesn't work for HTTPS connection yet. 
+
 ## 3.8.0 [2021-04-01]
 ### Features
  - [#143](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/143) - `InfluxDBClient::setInsecure` now works also for ESP32. Requires Arduino ESP32 SDK 1.0.5 or higher

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -319,6 +319,9 @@ void InfluxDBClient::setHTTPOptions(const HTTPOptions & httpOptions) {
     }
     _httpClient->setReuse(_httpOptions._connectionReuse);
     _httpClient->setTimeout(_httpOptions._httpReadTimeout);
+#if defined(ESP32) 
+     _httpClient->setConnectTimeout(_httpOptions._httpReadTimeout);
+#endif
 }
 
 void InfluxDBClient::resetBuffer() {


### PR DESCRIPTION
Closes #149

## Proposed Changes

ESP32 only: Setting `httpReadTimeout` also for `connectTimeout` of `HTTPClient`.

## Checklist


- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
