### PR TITLE
fix: flushing not full buffer when timeout occurs for the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
  - [#150](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/150) - `HTTPOptions::httpReadTimeout` is also set as the connect timeout for HTTP connection on ESP32. It doesn't work for HTTPS connection yet. 
  - [#156](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/156) - Correctly rounding _writeBufferSize_, when _bufferSize/batchSize >= 256_. 
+ - [#162](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/162) - Fixed flushing of not full buffer after to timeout.
 
 ## 3.8.0 [2021-04-01]
 ### Features

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -200,7 +200,7 @@ class InfluxDBClient {
     // Index of bath start for next write
     uint8_t _batchPointer = 0;
     // Last time in sec buffer has been successfully flushed
-    uint32_t _lastFlushed = 0;
+    uint32_t _lastFlushed;
     // Bucket sub-client
     BucketsClient _buckets;
   protected:    

--- a/src/Point.h
+++ b/src/Point.h
@@ -29,6 +29,7 @@
 
 #include <Arduino.h>
 #include "WritePrecision.h"
+#include "util/helpers.h"
 
 /**
  * Class Point represents InfluxDB point in line protocol.
@@ -49,7 +50,7 @@ friend class InfluxDBClient;
     void addField(String name, unsigned int value)  { putField(name, String(value)+"i"); }
     void addField(String name, long value)          { putField(name, String(value)+"i"); }
     void addField(String name, unsigned long value) { putField(name, String(value)+"i"); }
-    void addField(String name, bool value)          { putField(name,value?"true":"false"); }
+    void addField(String name, bool value)          { putField(name, bool2string(value)); }
     void addField(String name, String value)        { addField(name, value.c_str()); }
     void addField(String name, const char *value);
     // Set timestamp to `now()` and store it in specified precision, nanoseconds by default. Date and time must be already set. See `configTime` in the device API

--- a/src/query/HttpStreamScanner.cpp
+++ b/src/query/HttpStreamScanner.cpp
@@ -29,6 +29,7 @@
 // Uncomment bellow in case of a problem and rebuild sketch
 //#define INFLUXDB_CLIENT_DEBUG_ENABLE
 #include "util/debug.h"
+#include "util/helpers.h"
 
 HttpStreamScanner::HttpStreamScanner(HTTPClient *client, bool chunked)
 {
@@ -37,7 +38,7 @@ HttpStreamScanner::HttpStreamScanner(HTTPClient *client, bool chunked)
     _chunked = chunked;
     _chunkHeader = chunked;
     _len = client->getSize();
-    INFLUXDB_CLIENT_DEBUG("[D] HttpStreamScanner: chunked: %s, size: %d\n", _chunked?"true":"false", _len);
+    INFLUXDB_CLIENT_DEBUG("[D] HttpStreamScanner: chunked: %s, size: %d\n", bool2string(_chunked), _len);
 }
 
 bool HttpStreamScanner::next() {

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -161,3 +161,6 @@ bool isValidID(const char *idString) {
    return true;
 }
 
+const char *bool2string(bool val) {
+    return (val?"true":"false");
+}

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -50,6 +50,7 @@ String escapeValue(const char *value);
 String urlEncode(const char* src);
 // Returns true of string contains valid InfluxDB ID type
 bool isValidID(const char *idString);
-
+// Return "true" if val is true, otherwise "false"
+const char *bool2string(bool val);
 
 #endif //_INFLUXDB_CLIENT_HELPERS_H

--- a/test/Test.h
+++ b/test/Test.h
@@ -70,6 +70,7 @@ private: // tests
     static void testRepeatedInit();
     static void testIsValidID();
     static void testBuckets();
+    static void testFlushing();
 };
 
 #endif //_TEST_H_


### PR DESCRIPTION
Closes #160, closes #161

## Proposed Changes

Fixed flushing of buffer when flush interval timeout occurred
 - for the first time
 - when buffer was not full

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
