### PR TITLE
feat: disabling retrying, added writeRecord(const char *record)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 ## unreleased
 ### Features
-### Fixes
+ - [167](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/167) - Added `InfluxDBClient::writeRecord(const char *record)`.
+ - [167](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/167) - Added possibility to disable retrying by setting `maxRetryAttempts` to zero: `client.setWriteOptions(WriteOptions().maxRetryAttempts(0));` 
 
 ## 3.9.0 [2021-09-17]
 ### Features

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -123,6 +123,7 @@ class InfluxDBClient {
     // Writes record in InfluxDB line protocol format to write buffer.
     // Returns true if successful, false in case of any error 
     bool writeRecord(String &record);
+    bool writeRecord(const char *record);
     // Writes record represented by Point to buffer
     // Returns true if successful, false in case of any error 
     bool writePoint(Point& point);
@@ -172,7 +173,7 @@ class InfluxDBClient {
         uint8_t retryCount = 0;
         Batch(int size):_size(size) {  buffer = new String[size]; }
         ~Batch() { delete [] buffer; }
-        bool append(String &line);
+        bool append(const char *line);
         char *createData();
         bool isFull() const {
           return pointer == _size;

--- a/test/Test.h
+++ b/test/Test.h
@@ -71,6 +71,7 @@ private: // tests
     static void testIsValidID();
     static void testBuckets();
     static void testFlushing();
+    static void testNonRetry();
 };
 
 #endif //_TEST_H_


### PR DESCRIPTION
## Proposed Changes
 - Added possibility to disable retrying by setting `maxRetryAttempts` to zero: `client.setWriteOptions(WriteOptions().maxRetryAttempts(0));` 
 - Added `InfluxDBClient::writeRecord(const char *record)`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
