### PR TITLE
feat: all strings by ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## unreleased
+### Features
+ - [174](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/174) - All API methods with a string param allow specifying string by all basic types of :
+  - Arduino `String` class
+  - C `char *` or `char[]` 
+  - Flash string using `F`,`PSTR` or `FPSTR` macros
+
 ## 3.10.0 [2022-01-20]
 ### Features
  - [167](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/167) - Added `InfluxDBClient::writeRecord(const char *record)`.

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -34,7 +34,7 @@
 
 static const char TooEarlyMessage[] PROGMEM = "Cannot send request yet because of applied retry strategy. Remaining ";
 
-static String escapeJSONString(String &value);
+static String escapeJSONString(const String &value);
 static String precisionToString(WritePrecision precision, uint8_t version = 2) {
     switch(precision) {
         case WritePrecision::US:
@@ -352,7 +352,7 @@ char * InfluxDBClient::Batch::createData() {
     return buff;
 }
 
-bool InfluxDBClient::writeRecord(String &record) {
+bool InfluxDBClient::writeRecord(const String &record) {
     return writeRecord(record.c_str());
 }
 
@@ -577,11 +577,11 @@ static const char QueryDialect[] PROGMEM = "\
 static const char Params[] PROGMEM = ",\
 \"params\": {";
 
-FluxQueryResult InfluxDBClient::query(String fluxQuery) {
+FluxQueryResult InfluxDBClient::query(const String &fluxQuery) {
     return query(fluxQuery, QueryParams());
 }
 
-FluxQueryResult InfluxDBClient::query(String fluxQuery, QueryParams params) {
+FluxQueryResult InfluxDBClient::query(const String &fluxQuery, QueryParams params) {
     uint32_t rwt = getRemainingRetryTime();
     if(rwt > 0) {
         INFLUXDB_CLIENT_DEBUG("[W] Cannot query yet, pause %ds, %ds yet\n", _retryTime, rwt);
@@ -638,7 +638,7 @@ FluxQueryResult InfluxDBClient::query(String fluxQuery, QueryParams params) {
 }
 
 
-static String escapeJSONString(String &value) {
+static String escapeJSONString(const String &value) {
     String ret;
     int d = 0;
     int i,from = 0;

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -122,7 +122,7 @@ class InfluxDBClient {
     bool validateConnection();
     // Writes record in InfluxDB line protocol format to write buffer.
     // Returns true if successful, false in case of any error 
-    bool writeRecord(String &record);
+    bool writeRecord(const String &record);
     bool writeRecord(const char *record);
     // Writes record represented by Point to buffer
     // Returns true if successful, false in case of any error 
@@ -130,11 +130,11 @@ class InfluxDBClient {
     // Sends Flux query and returns FluxQueryResult object for subsequently reading flux query response.
     // Use FluxQueryResult::next() method to iterate over lines of the query result.
     // Always call of FluxQueryResult::close() when reading is finished. Check FluxQueryResult doc for more info.
-    FluxQueryResult query(String fluxQuery);
+    FluxQueryResult query(const String &fluxQuery);
     // Sends Flux query with params and returns FluxQueryResult object for subsequently reading flux query response.
     // Use FluxQueryResult::next() method to iterate over lines of the query result.
     // Always call of FluxQueryResult::close() when reading is finished. Check FluxQueryResult doc for more info.
-    FluxQueryResult query(String fluxQuery, QueryParams params);
+    FluxQueryResult query(const String &fluxQuery, QueryParams params);
     // Forces writing of all points in buffer, even the batch is not full.
     // Returns true if successful, false in case of any error 
     bool flushBuffer();

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -28,7 +28,7 @@
 #include "Options.h"
 #include "util/helpers.h"
 
-WriteOptions& WriteOptions::addDefaultTag(String name, String value) { 
+WriteOptions& WriteOptions::addDefaultTag(const String &name, const String &value) { 
     if(_defaultTags.length() > 0) {
         _defaultTags += ',';
     }

--- a/src/Options.h
+++ b/src/Options.h
@@ -81,7 +81,7 @@ public:
     WriteOptions& retryInterval(uint16_t retryIntervalSec) { _retryInterval = retryIntervalSec; return *this; }
     WriteOptions& maxRetryInterval(uint16_t maxRetryIntervalSec) { _maxRetryInterval = maxRetryIntervalSec; return *this; }
     WriteOptions& maxRetryAttempts(uint16_t maxRetryAttempts) { _maxRetryAttempts = maxRetryAttempts; return *this; }
-    WriteOptions& addDefaultTag(String name, String value);
+    WriteOptions& addDefaultTag(const String &name, const String &value);
     WriteOptions& clearDefaultTags() { _defaultTags = (char *)nullptr; return *this; }
 };
 

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -28,7 +28,7 @@
 #include "Point.h"
 #include "util/helpers.h"
 
-Point::Point(String measurement):
+Point::Point(const String & measurement):
     _measurement(escapeKey(measurement, false)),
     _tags(""),
     _fields(""),
@@ -37,7 +37,7 @@ Point::Point(String measurement):
 
 }
 
-void Point::addTag(String name, String value) {
+void Point::addTag(const String &name, String value) {
     if(_tags.length() > 0) {
         _tags += ',';
     }
@@ -46,23 +46,67 @@ void Point::addTag(String name, String value) {
     _tags += escapeKey(value);
 }
 
-void Point::addField(String name, long long value) {
+void Point::addField(const String &name, long long value) {
   char buff[50];
   snprintf(buff, 50, "%lld", value);
   putField(name, String(buff)+"i");
 }
 
-void Point::addField(String name, unsigned long long value) {
+void Point::addField(const String &name, unsigned long long value) {
   char buff[50];
   snprintf(buff, 50, "%llu", value);
   putField(name, String(buff)+"i");
 }
 
-void Point::addField(String name, const char *value) { 
-    putField(name, "\"" + escapeValue(value) + "\""); 
+void Point::addField(const String &name, const char *value) { 
+    putField(name, escapeValue(value)); 
 }
 
-void Point::putField(String name, String value) {
+void Point::addField(const String &name, const __FlashStringHelper *pstr) {
+    addField(name, String(pstr));
+}
+
+void Point::addField(const String &name, float value, int decimalPlaces) { 
+    if(!isnan(value)) putField(name, String(value, decimalPlaces)); 
+}
+
+void Point::addField(const String &name, double value, int decimalPlaces) {
+    if(!isnan(value)) putField(name, String(value, decimalPlaces)); 
+}
+
+void Point::addField(const String &name, char value) { 
+    addField(name, String(value).c_str()); 
+}
+
+void Point::addField(const String &name, unsigned char value) {
+    putField(name, String(value)+"i"); 
+}
+
+void Point::addField(const String &name, int value) { 
+    putField(name, String(value)+"i"); 
+}
+
+void Point::addField(const String &name, unsigned int value) { 
+    putField(name, String(value)+"i"); 
+}
+
+void Point::addField(const String &name, long value)  { 
+    putField(name, String(value)+"i"); 
+}
+
+void Point::addField(const String &name, unsigned long value) { 
+    putField(name, String(value)+"i"); 
+}
+
+void Point::addField(const String &name, bool value)  { 
+    putField(name, bool2string(value)); 
+}
+
+void Point::addField(const String &name, const String &value)  { 
+    addField(name, value.c_str()); 
+}
+
+void Point::putField(const String &name, const String &value) {
     if(_fields.length() > 0) {
         _fields += ',';
     }
@@ -71,11 +115,11 @@ void Point::putField(String name, String value) {
     _fields += value;
 }
 
-String Point::toLineProtocol(String includeTags) const {
+String Point::toLineProtocol(const String &includeTags) const {
     return createLineProtocol(includeTags);
 }
 
-String Point::createLineProtocol(String &incTags) const {
+String Point::createLineProtocol(const String &incTags) const {
     String line;
     line.reserve(_measurement.length() + 1 + incTags.length() + 1 + _tags.length() + 1 + _fields.length() + 1 + _timestamp.length());
     line += _measurement;
@@ -125,7 +169,7 @@ void  Point::setTime(unsigned long long timestamp) {
     _timestamp = timeStampToString(timestamp);
 }
 
-void  Point::setTime(String timestamp) {
+void  Point::setTime(const String &timestamp) {
     _timestamp = timestamp;
 }
 

--- a/src/Point.h
+++ b/src/Point.h
@@ -38,29 +38,30 @@
 class Point {
 friend class InfluxDBClient;
   public:
-    Point(String measurement);
+    Point(const String &measurement);
     // Adds string tag 
-    void addTag(String name, String value);
+    void addTag(const String &name, String value);
     // Add field with various types
-    void addField(String name, float value, int decimalPlaces = 2)         { if(!isnan(value)) putField(name, String(value, decimalPlaces)); }
-    void addField(String name, double value, int decimalPlaces = 2)        { if(!isnan(value)) putField(name, String(value, decimalPlaces)); }
-    void addField(String name, char value)          { addField(name, String(value).c_str()); }
-    void addField(String name, unsigned char value) { putField(name, String(value)+"i"); }
-    void addField(String name, int value)           { putField(name, String(value)+"i"); }
-    void addField(String name, unsigned int value)  { putField(name, String(value)+"i"); }
-    void addField(String name, long value)          { putField(name, String(value)+"i"); }
-    void addField(String name, unsigned long value) { putField(name, String(value)+"i"); }
-    void addField(String name, bool value)          { putField(name, bool2string(value)); }
-    void addField(String name, String value)        { addField(name, value.c_str()); }
-    void addField(String name, long long value);
-    void addField(String name, unsigned long long value);
-    void addField(String name, const char *value);
+    void addField(const String &name, float value, int decimalPlaces = 2);
+    void addField(const String &name, double value, int decimalPlaces = 2);
+    void addField(const String &name, char value);
+    void addField(const String &name, unsigned char value);
+    void addField(const String &name, int value);
+    void addField(const String &name, unsigned int value);
+    void addField(const String &name, long value);
+    void addField(const String &name, unsigned long value);
+    void addField(const String &name, bool value);
+    void addField(const String &name, const String &value);
+    void addField(const String &name, const __FlashStringHelper *pstr);
+    void addField(const String &name, long long value);
+    void addField(const String &name, unsigned long long value);
+    void addField(const String &name, const char *value);
     // Set timestamp to `now()` and store it in specified precision, nanoseconds by default. Date and time must be already set. See `configTime` in the device API
     void setTime(WritePrecision writePrecision = WritePrecision::NS);
     // Set timestamp in offset since epoch (1.1.1970). Correct precision must be set InfluxDBClient::setWriteOptions.
     void setTime(unsigned long long timestamp);
     // Set timestamp in offset since epoch (1.1.1970 00:00:00). Correct precision must be set InfluxDBClient::setWriteOptions.
-    void setTime(String timestamp);
+    void setTime(const String &timestamp);
     // Clear all fields. Usefull for reusing point  
     void clearFields();
     // Clear tags
@@ -72,7 +73,7 @@ friend class InfluxDBClient;
     // True if a point contains timestamp
     bool hasTime() const   { return _timestamp.length() > 0; }
     // Creates line protocol with optionally added tags
-    String toLineProtocol(String includeTags = "") const;
+    String toLineProtocol(const String &includeTags = "") const;
     // returns current timestamp
     String getTime() const { return _timestamp; } 
   protected:
@@ -82,8 +83,8 @@ friend class InfluxDBClient;
     String _timestamp;
   protected:    
     // method for formating field into line protocol
-    void putField(String name, String value);
+    void putField(const String &name, const String &value);
     // Creates line protocol string
-    String createLineProtocol(String &incTags) const;
+    String createLineProtocol(const String &incTags) const;
 };
 #endif //_POINT_H_

--- a/src/query/FluxParser.cpp
+++ b/src/query/FluxParser.cpp
@@ -34,7 +34,7 @@ FluxQueryResult::FluxQueryResult(CsvReader *reader) {
     _data = std::make_shared<Data>(reader);
 }
 
-FluxQueryResult::FluxQueryResult(String error):FluxQueryResult((CsvReader *)nullptr) {
+FluxQueryResult::FluxQueryResult(const String &error):FluxQueryResult((CsvReader *)nullptr) {
     _data->_error = error;
 }
 
@@ -51,7 +51,7 @@ FluxQueryResult &FluxQueryResult::operator=(const FluxQueryResult &other) {
 FluxQueryResult::~FluxQueryResult() {
 }
 
-int FluxQueryResult::getColumnIndex(String columnName) {
+int FluxQueryResult::getColumnIndex(const String &columnName) {
     int i = -1;
     std::vector<String>::iterator it = find(_data->_columnNames.begin(), _data->_columnNames.end(), columnName);
     if (it != _data->_columnNames.end()) {
@@ -68,7 +68,7 @@ FluxValue FluxQueryResult::getValueByIndex(int index) {
     return ret;
 }
 
-FluxValue FluxQueryResult::getValueByName(String columnName) {
+FluxValue FluxQueryResult::getValueByName(const String &columnName) {
     FluxValue ret;
     int i = getColumnIndex(columnName);
     if(i > -1) {

--- a/src/query/FluxParser.h
+++ b/src/query/FluxParser.h
@@ -54,7 +54,7 @@ public:
     // Constructor for reading result
     FluxQueryResult(CsvReader *reader);
     // Constructor for error result
-    FluxQueryResult(String error);
+    FluxQueryResult(const String &error);
     // Copy constructor
     FluxQueryResult(const FluxQueryResult &other);
     // Assignment operator
@@ -64,11 +64,11 @@ public:
     // or an error. Call getError() and check non empty value
     bool next();
     // Returns index of the column, or -1 if not found
-    int getColumnIndex(String columnName);
+    int getColumnIndex(const String &columnName);
     // Returns a converted value by index, or nullptr in case of missing value or wrong index
     FluxValue getValueByIndex(int index);
     // Returns a result value by column name, or nullptr in case of missing value or wrong column name
-    FluxValue getValueByName(String columnName);
+    FluxValue getValueByName(const String &columnName);
     // Returns flux datatypes of all columns
     std::vector<String> getColumnsDatatype() { return _data->_columnDatatypes; }
     // Returns names of all columns

--- a/src/query/FluxTypes.cpp
+++ b/src/query/FluxTypes.cpp
@@ -38,7 +38,7 @@ const char	*FluxBinaryDataTypeBase64         = "base64Binary";
 const char	*FluxDatatypeDatetimeRFC3339      = "dateTime:RFC3339";
 const char	*FluxDatatypeDatetimeRFC3339Nano  = "dateTime:RFC3339Nano";
 
-FluxBase::FluxBase(String rawValue) {
+FluxBase::FluxBase(const String &rawValue) {
     _rawValue = rawValue;
 }
 
@@ -46,7 +46,7 @@ FluxBase::~FluxBase() {
 }
 
 
-FluxLong::FluxLong(String rawValue, long value):FluxBase(rawValue),value(value) {
+FluxLong::FluxLong(const String &rawValue, long value):FluxBase(rawValue),value(value) {
 
 }
 
@@ -62,7 +62,7 @@ char *FluxLong::jsonString() {
 }
 
 
-FluxUnsignedLong::FluxUnsignedLong(String rawValue, unsigned long value):FluxBase(rawValue),value(value) {
+FluxUnsignedLong::FluxUnsignedLong(const String &rawValue, unsigned long value):FluxBase(rawValue),value(value) {
 }
 
 const char *FluxUnsignedLong::getType() {
@@ -76,11 +76,11 @@ char *FluxUnsignedLong::jsonString() {
   return json;
 }
 
-FluxDouble::FluxDouble(String rawValue, double value):FluxDouble(rawValue, value, 0) {
+FluxDouble::FluxDouble(const String &rawValue, double value):FluxDouble(rawValue, value, 0) {
    
 }
 
-FluxDouble::FluxDouble(String rawValue, double value, int precision):FluxBase(rawValue),
+FluxDouble::FluxDouble(const String &rawValue, double value, int precision):FluxBase(rawValue),
   value(value),precision(precision) {}
 
 const char *FluxDouble::getType() {
@@ -96,7 +96,7 @@ char *FluxDouble::jsonString() {
     return json;
 }
 
-FluxBool::FluxBool(String rawValue, bool value):FluxBase(rawValue),value(value) {   
+FluxBool::FluxBool(const String &rawValue, bool value):FluxBase(rawValue),value(value) {   
 }
 
 const char *FluxBool::getType() {
@@ -111,7 +111,7 @@ char *FluxBool::jsonString() {
 }
 
 
-FluxDateTime::FluxDateTime(String rawValue, const char *type, struct tm value, unsigned long microseconds):FluxBase(rawValue),_type(type),value(value), microseconds(microseconds) {
+FluxDateTime::FluxDateTime(const String &rawValue, const char *type, struct tm value, unsigned long microseconds):FluxBase(rawValue),_type(type),value(value), microseconds(microseconds) {
 
 }
 
@@ -119,7 +119,7 @@ const char *FluxDateTime::getType() {
     return _type;
 }
 
-String FluxDateTime::format(String formatString) {
+String FluxDateTime::format(const String &formatString) {
   int len = formatString.length() + 20; //+20 for safety
   char *buff = new char[len];
   strftime(buff,len, formatString.c_str(),&value);
@@ -140,11 +140,11 @@ char *FluxDateTime::jsonString() {
   return buff;
 }
 
-FluxString::FluxString(String rawValue, const char *type):FluxString(rawValue, rawValue, type) {
+FluxString::FluxString(const String &rawValue, const char *type):FluxString(rawValue, rawValue, type) {
 
 }
 
-FluxString::FluxString(String rawValue, String value, const char *type):FluxBase(rawValue),value(value),_type(type)
+FluxString::FluxString(const String &rawValue, const String &value, const char *type):FluxBase(rawValue),value(value),_type(type)
 {
 
 }

--- a/src/query/FluxTypes.h
+++ b/src/query/FluxTypes.h
@@ -55,7 +55,7 @@ class FluxBase {
 protected:
     String _rawValue;
 public:
-    FluxBase(String rawValue);
+    FluxBase(const String &rawValue);
     virtual ~FluxBase();
     String getRawValue() const { return _rawValue; }
     virtual const char *getType() = 0;
@@ -65,7 +65,7 @@ public:
 // Represents flux long
 class FluxLong : public FluxBase {
 public:
-    FluxLong(String rawValue, long value);
+    FluxLong(const String &rawValue, long value);
     long value;
     virtual const char *getType() override;
     virtual char *jsonString() override;
@@ -74,7 +74,7 @@ public:
 // Represents flux unsignedLong
 class FluxUnsignedLong : public FluxBase {
 public:
-    FluxUnsignedLong(String rawValue, unsigned long value);
+    FluxUnsignedLong(const String &rawValue, unsigned long value);
     unsigned long value;
     virtual const char *getType() override;
     virtual char *jsonString() override;
@@ -83,8 +83,8 @@ public:
 // Represents flux double
 class FluxDouble : public FluxBase {
 public:
-    FluxDouble(String rawValue, double value);
-    FluxDouble(String rawValue, double value, int precision);
+    FluxDouble(const String &rawValue, double value);
+    FluxDouble(const String &rawValue, double value, int precision);
     double value;
     // For JSON serialization
     int precision;
@@ -95,7 +95,7 @@ public:
 // Represents flux bool
 class FluxBool : public FluxBase {
 public:
-    FluxBool(String rawValue, bool value);
+    FluxBool(const String &rawValue, bool value);
     bool value;
     virtual const char *getType() override;
     virtual char *jsonString() override;
@@ -109,14 +109,14 @@ class FluxDateTime : public FluxBase {
 protected:
     const char *_type;
 public:    
-    FluxDateTime(String rawValue, const char *type, struct tm value, unsigned long microseconds);
+    FluxDateTime(const String &rawValue, const char *type, struct tm value, unsigned long microseconds);
     // Struct tm for date and time
     struct tm value;
     // microseconds part
     unsigned long microseconds;
     // Formats the value part to string according to the given format. Microseconds are skipped.
     // Format string must be compatible with the http://www.cplusplus.com/reference/ctime/strftime/
-    String format(String formatString);
+    String format(const String &formatString);
     virtual const char *getType() override;
     virtual char *jsonString() override;
 };
@@ -126,8 +126,8 @@ class FluxString : public FluxBase {
 protected:
     const char *_type;
 public:
-    FluxString(String rawValue, const char *type);
-    FluxString(String rawValue, String value, const char *type);
+    FluxString(const String &rawValue, const char *type);
+    FluxString(const String &rawValue, const String &value, const char *type);
     String value;
     virtual const char *getType() override;
     virtual char *jsonString() override;

--- a/src/query/Params.cpp
+++ b/src/query/Params.cpp
@@ -51,49 +51,64 @@ QueryParams &QueryParams::operator=(const QueryParams &other) {
   return *this;
 }
 
-QueryParams &QueryParams::add(const char *name, float value, int decimalPlaces) {
+QueryParams &QueryParams::add(const String &name, float value, int decimalPlaces) {
   return add(name, (double)value);
 }
 
-QueryParams &QueryParams::add(const char *name, double value, int decimalPlaces) {
+QueryParams &QueryParams::add(const String &name, double value, int decimalPlaces) {
   return add(new FluxDouble(name, value, decimalPlaces));
 }
 
-QueryParams &QueryParams::add(const char *name, char value) {
+QueryParams &QueryParams::add(const String &name, char value) {
   String s(value);
   return add(name, s);
 }
-QueryParams &QueryParams::add(const char *name, unsigned char value) {
+
+QueryParams &QueryParams::add(const String &name, unsigned char value) {
   return add(name, (unsigned long)value);
 }
-QueryParams &QueryParams::add(const char *name, int value) {
+
+QueryParams &QueryParams::add(const String &name, int value) {
   return add(name,(long)value);
 }
-QueryParams &QueryParams::add(const char *name, unsigned int value) {
+
+QueryParams &QueryParams::add(const String &name, unsigned int value) {
   return add(name,(unsigned long)value);
 }
-QueryParams &QueryParams::add(const char *name, long value) {
+
+QueryParams &QueryParams::add(const String &name, long value) {
     return add(new FluxLong(name, value));
 }
-QueryParams &QueryParams::add(const char *name, unsigned long value) {
+
+QueryParams &QueryParams::add(const String &name, unsigned long value) {
   return add(new FluxUnsignedLong(name, value));
 }
-QueryParams &QueryParams::add(const char *name, bool value) {
+
+QueryParams &QueryParams::add(const String &name, bool value) {
   return add(new FluxBool(name, value));
 }
-QueryParams &QueryParams::add(const char *name, String &value) {
+
+QueryParams &QueryParams::add(const String &name, const String &value) {
   return add(name, value.c_str());
 }
-QueryParams &QueryParams::add(const char *name, long long value)  {
+
+QueryParams &QueryParams::add(const String &name, const __FlashStringHelper *pstr) {
+  return add(name, String(pstr));
+}
+
+QueryParams &QueryParams::add(const String &name, long long value)  {
   return add(name,(long)value);
 }
-QueryParams &QueryParams::add(const char *name, unsigned long long value) {
+
+QueryParams &QueryParams::add(const String &name, unsigned long long value) {
   return add(name,(unsigned long)value);
 }
-QueryParams &QueryParams::add(const char *name, const char *value) {
+
+QueryParams &QueryParams::add(const String &name, const char *value) {
   return add(new FluxString(name, value, FluxDatatypeString));
 }
-QueryParams &QueryParams::add(const char *name, struct tm tm, unsigned long micros ) {
+
+QueryParams &QueryParams::add(const String &name, struct tm tm, unsigned long micros ) {
   return add(new FluxDateTime(name, FluxDatatypeDatetimeRFC3339Nano, tm, micros));
 }
 
@@ -104,7 +119,7 @@ QueryParams &QueryParams::add(FluxBase *value) {
   return *this;
 }
 
-void QueryParams::remove(const char *name) {
+void QueryParams::remove(const String &name) {
   if(_data) {
     auto it = std::find_if(_data->begin(),_data->end(), [name](FluxBase *f){ return f->getRawValue() == name; } );
     if(it != _data->end()) {

--- a/src/query/Params.h
+++ b/src/query/Params.h
@@ -48,37 +48,39 @@ class QueryParams {
     // Descructor
     ~QueryParams();
     // Adds param with a float value. A number of decimal places can be optionally set.
-    QueryParams &add(const char *name, float value, int decimalPlaces = 2);
+    QueryParams &add(const String &name, float value, int decimalPlaces = 2);
     // Adds param with a double value. A number of decimal places can be optionally set.
-    QueryParams &add(const char *name, double value, int decimalPlaces = 2); 
+    QueryParams &add(const String &name, double value, int decimalPlaces = 2); 
     // Adds param with a character value.
-    QueryParams &add(const char *name, char value);
+    QueryParams &add(const String &name, char value);
     // Adds param with an unsigned character value. It is added as a number.
-    QueryParams &add(const char *name, unsigned char value);
+    QueryParams &add(const String &name, unsigned char value);
     // Adds param with an integer value.
-    QueryParams &add(const char *name, int value);
+    QueryParams &add(const String &name, int value);
     // Adds param with an unsigned integer value.
-    QueryParams &add(const char *name, unsigned int value);
+    QueryParams &add(const String &name, unsigned int value);
     // Adds param with a long value.
-    QueryParams &add(const char *name, long value);
+    QueryParams &add(const String &name, long value);
     // Adds param with an unsigned long value.
-    QueryParams &add(const char *name, unsigned long value);
+    QueryParams &add(const String &name, unsigned long value);
     // Adds param with a boolen value.
-    QueryParams &add(const char *name, bool value);
+    QueryParams &add(const String &name, bool value);
     // Adds param with a String value.
-    QueryParams &add(const char *name, String &value);
+    QueryParams &add(const String &name, const String &value);
+    // Adds param with a progmem string value.
+    QueryParams &add(const String &name, const __FlashStringHelper *pstr);
     // Adds param with a long long value. It is converted to long.
-    QueryParams &add(const char *name, long long value);
+    QueryParams &add(const String &name, long long value);
     // Adds param with an unsigned long long value. It is converted to long.
-    QueryParams &add(const char *name, unsigned long long value);
+    QueryParams &add(const String &name, unsigned long long value);
     // Adds param with a string value.
-    QueryParams &add(const char *name, const char *value);
+    QueryParams &add(const String &name, const char *value);
     // Adds param as a string representation of date-time value in UTC timezone, e.g. "2022-01-12T23:12:30.124Z"
     // Micros is fractional part of seconds up to microseconds precision. E.g. if millisecond are provided
     // it must be converted to microseconds: micros = 1000*millis
-    QueryParams &add(const char *name, struct tm tm, unsigned long micros = 0);
+    QueryParams &add(const String &name, struct tm tm, unsigned long micros = 0);
     // Removed a param
-    void remove(const char *name);
+    void remove(const String &name);
     // Returns i-th param
     FluxBase *get(int i);
     // Returns params count

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -74,7 +74,7 @@ String timeStampToString(unsigned long long timestamp) {
     return String(buff);
 }
 
-String escapeKey(String key, bool escapeEqual) {
+String escapeKey(const String &key, bool escapeEqual) {
     String ret;
     ret.reserve(key.length()+5); //5 is estimate of  chars needs to escape,
 
@@ -103,7 +103,8 @@ String escapeKey(String key, bool escapeEqual) {
 String escapeValue(const char *value) {
     String ret;
     int len = strlen_P(value);
-    ret.reserve(len+5); //5 is estimate of max chars needs to escape,
+    ret.reserve(len+7); //5 is estimate of max chars needs to escape,
+    ret += '"';
     for(int i=0;i<len;i++)
     {
         switch (value[i])
@@ -116,6 +117,7 @@ String escapeValue(const char *value) {
 
         ret += value[i];
     }
+    ret += '"';
     return ret;
 }
 

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -42,7 +42,7 @@ unsigned long long getTimeStamp(struct timeval *tv, int secFracDigits = 3);
 String timeStampToString(unsigned long long timestamp);
 
 // Escape invalid chars in measurement, tag key, tag value and field key
-String escapeKey(String key, bool escapeEqual = true);
+String escapeKey(const String &key, bool escapeEqual = true);
 
 // Escape invalid chars in field value
 String escapeValue(const char *value);

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -235,7 +235,11 @@ void Test::testPoint() {
     Point p("test");
     TEST_ASSERT(!p.hasTags());
     TEST_ASSERT(!p.hasFields());
+    String name = "tag3";
+    String value = "tagvalue3";
     p.addTag("tag1", "tagvalue");
+    p.addTag(F("tag2"), F("tagvalue2"));
+    p.addTag(name, value);
     TEST_ASSERT(p.hasTags());
     TEST_ASSERT(!p.hasFields());
     p.addField("fieldInt", -23);
@@ -243,8 +247,9 @@ void Test::testPoint() {
     p.addField("fieldBool", true);
     p.addField("fieldFloat1", 1.123f);
     p.addField("fieldFloat2", 1.12345f, 5);
-    p.addField("fieldDouble1", 1.123);
-    p.addField("fieldDouble2", 1.12345, 5);
+    p.addField(F("fieldDouble1"), 1.123);
+    name = "fieldDouble2";
+    p.addField(name, 1.12345, 5);
     p.addField("fieldChar", 'A');
     p.addField("fieldUChar", (unsigned char)1);
     p.addField("fieldUInt", 23u);
@@ -253,18 +258,22 @@ void Test::testPoint() {
     p.addField("fieldLongLong", 9123456789l);
     p.addField("fieldULongLong", 9123456789ul);
     p.addField("fieldString", "text test");
+    p.addField(F("fieldString2"), F("text test2"));
+    name = "fieldString3";
+    value = "text test3";
+    p.addField(name, value);
     String line = p.toLineProtocol();
-    String testLine = "test,tag1=tagvalue fieldInt=-23i,fieldBool=true,fieldFloat1=1.12,fieldFloat2=1.12345,fieldDouble1=1.12,fieldDouble2=1.12345,fieldChar=\"A\",fieldUChar=1i,fieldUInt=23i,fieldLong=123456i,fieldULong=123456i,fieldLongLong=9123456789i,fieldULongLong=9123456789i,fieldString=\"text test\"";
+    String testLine = "test,tag1=tagvalue,tag2=tagvalue2,tag3=tagvalue3 fieldInt=-23i,fieldBool=true,fieldFloat1=1.12,fieldFloat2=1.12345,fieldDouble1=1.12,fieldDouble2=1.12345,fieldChar=\"A\",fieldUChar=1i,fieldUInt=23i,fieldLong=123456i,fieldULong=123456i,fieldLongLong=9123456789i,fieldULongLong=9123456789i,fieldString=\"text test\",fieldString2=\"text test2\",fieldString3=\"text test3\"";
     TEST_ASSERTM(line == testLine, line);
 
     String defaultTags="dtag=val";
     line = p.toLineProtocol(defaultTags);
-    testLine = "test,dtag=val,tag1=tagvalue fieldInt=-23i,fieldBool=true,fieldFloat1=1.12,fieldFloat2=1.12345,fieldDouble1=1.12,fieldDouble2=1.12345,fieldChar=\"A\",fieldUChar=1i,fieldUInt=23i,fieldLong=123456i,fieldULong=123456i,fieldLongLong=9123456789i,fieldULongLong=9123456789i,fieldString=\"text test\"";
+    testLine = "test,dtag=val,tag1=tagvalue,tag2=tagvalue2,tag3=tagvalue3 fieldInt=-23i,fieldBool=true,fieldFloat1=1.12,fieldFloat2=1.12345,fieldDouble1=1.12,fieldDouble2=1.12345,fieldChar=\"A\",fieldUChar=1i,fieldUInt=23i,fieldLong=123456i,fieldULong=123456i,fieldLongLong=9123456789i,fieldULongLong=9123456789i,fieldString=\"text test\",fieldString2=\"text test2\",fieldString3=\"text test3\"";
     TEST_ASSERTM(line == testLine, line);
 
     p.clearTags();
     line = p.toLineProtocol(defaultTags);
-    testLine = "test,dtag=val fieldInt=-23i,fieldBool=true,fieldFloat1=1.12,fieldFloat2=1.12345,fieldDouble1=1.12,fieldDouble2=1.12345,fieldChar=\"A\",fieldUChar=1i,fieldUInt=23i,fieldLong=123456i,fieldULong=123456i,fieldLongLong=9123456789i,fieldULongLong=9123456789i,fieldString=\"text test\"";
+    testLine = "test,dtag=val fieldInt=-23i,fieldBool=true,fieldFloat1=1.12,fieldFloat2=1.12345,fieldDouble1=1.12,fieldDouble2=1.12345,fieldChar=\"A\",fieldUChar=1i,fieldUInt=23i,fieldLong=123456i,fieldULong=123456i,fieldLongLong=9123456789i,fieldULongLong=9123456789i,fieldString=\"text test\",fieldString2=\"text test2\",fieldString3=\"text test3\"";
     TEST_ASSERTM(line == testLine, line);
 
 
@@ -1484,8 +1493,8 @@ void Test::testQueryParams() {
     QueryParams params2;
     params2.add("char", '1');
     params2.add("uchar", (unsigned char)1);
-    params2.add("int", -1);
-    params2.add("uint", 1u);
+    params2.add(String("int"), -1);
+    params2.add(F("uint"), 1u);
     params2.add("long", -1l);
     params2.add("ulong", 1lu);
     params2.add("longlong", -1ll);
@@ -1494,10 +1503,11 @@ void Test::testQueryParams() {
     params2.add("double", 1.1);
     params2.add("bool", true);
     params2.add("cstring", "text");
+    params2.add(F("fstring"), F("text"));
     params2.add("dateTime", {15,34,9,22,4,120,0,0,0});
     String s = "string";
     params2.add("string", s);
-    TEST_ASSERT(params2.size() == 14);
+    TEST_ASSERT(params2.size() == 15);
 
     const char *types[] = {
         FluxDatatypeString,
@@ -1512,12 +1522,13 @@ void Test::testQueryParams() {
         FluxDatatypeDouble,
         FluxDatatypeBool,
         FluxDatatypeString,
+        FluxDatatypeString,
         FluxDatatypeDatetimeRFC3339Nano,
         FluxDatatypeString
     };
 
     for(int i=0;i<params2.size();i++) {
-        TEST_ASSERTM(params2.get(i)->getType() == types[i], String(i) + " " + types[i]);
+        TEST_ASSERTM(params2.get(i)->getType() == types[i], String(i) + " " + params2.get(i)->getType());
     }
 
     TEST_END();

--- a/test/TestBase.cpp
+++ b/test/TestBase.cpp
@@ -30,7 +30,7 @@ void TestBase::setup(const char * mgmtUrl, const char * apiUrl, const char *e2eA
     TestBase::token = token;
 }
 
-Point *TestBase::createPoint(String measurement) {
+Point *TestBase::createPoint(const String &measurement) {
     Point *point = new Point(measurement);
     point->addTag("SSID", WiFi.SSID());
     point->addTag("device_name", deviceName);

--- a/test/TestBase.h
+++ b/test/TestBase.h
@@ -53,7 +53,7 @@ public:
     static int failures;
 public:
     static void setup(const char * mgmtUrl, const char * apiUrl, const char *e2eApiUrl, const char * orgName, const char * bucketName, const char * dbName, const char * token);
-    static Point *createPoint(String measurement);
+    static Point *createPoint(const String &measurement);
 };
 
 bool testAssertm(int line, bool state,String message);

--- a/test/TestSupport.cpp
+++ b/test/TestSupport.cpp
@@ -41,7 +41,7 @@ void printFreeHeap() {
   Serial.println(ESP.getFreeHeap());
 }
 
-int httpPOST(String url, String mess) {
+int httpPOST(const String &url, String mess) {
   httpClient.setReuse(false);
   int code = 0;
   WiFiClient client;
@@ -52,7 +52,7 @@ int httpPOST(String url, String mess) {
   return code;
 }
 
-int httpGET(String url) {
+int httpGET(const String &url) {
   httpClient.setReuse(false);
   int code = 0;
   WiFiClient client;
@@ -68,20 +68,20 @@ int httpGET(String url) {
   return code;
 }
 
-bool deleteAll(String url) {
+bool deleteAll(const String &url) {
   return httpPOST(url + "/api/v2/delete","") == 204;
 }
 
-bool serverLog(String url, String mess) {
+bool serverLog(const String &url, String mess) {
   return httpPOST(url + "/log", mess) == 204;
 }
 
-bool isServerUp(String url) {
+bool isServerUp(const String &url) {
     return httpGET(url + "/status") == 200;
 }
 
 
-int countParts(String &str, char separator) {
+int countParts(const String &str, char separator) {
   int lines = 0;
   int i,from = 0;
   while((i = str.indexOf(separator, from)) >= 0) {
@@ -95,7 +95,7 @@ int countParts(String &str, char separator) {
   return lines;
 }
 
-String *getParts(String &str, char separator, int &count) {
+String *getParts(const String &str, char separator, int &count) {
   count = countParts(str, separator);
   String *ret = new String[count];
   int i,from = 0,p=0;
@@ -142,12 +142,12 @@ bool compareTm(tm &tm1, tm &tm2) {
     return difftime(t1, t2) == 0;
 } 
 
-bool waitServer(const char *url, bool state) {
+bool waitServer(const String &url, bool state) {
     int i = 0;
     while(isServerUp(url) != state && i<10 ) {
         if(!i) {
             Serial.println(state?"[TD] Starting server":"[TD] Shuting down server");
-            httpGET(String(url) + (state?"/start":"/stop"));
+            httpGET(url + (state?"/start":"/stop"));
         }
         delay(500);
         i++;

--- a/test/TestSupport.h
+++ b/test/TestSupport.h
@@ -32,20 +32,20 @@
 
 void printFreeHeap();
 
-int httpPOST(String url, String mess);
+int httpPOST(const String &url, String mess);
 
-int httpGET(String url);
+int httpGET(const String &url);
 
-bool deleteAll(String url) ;
+bool deleteAll(const String &url) ;
 
-bool serverLog(String url, String mess);
+bool serverLog(const String &url, String mess);
 
-bool isServerUp(String url);
+bool isServerUp(const String &url);
 
 
-int countParts(String &str, char separator);
+int countParts(const String &str, char separator);
 
-String *getParts(String &str, char separator, int &count);
+String *getParts(const String &str, char separator, int &count);
 
 int countLines(FluxQueryResult flux) ;
 
@@ -54,6 +54,6 @@ std::vector<String> getLines(FluxQueryResult flux);
 
 bool compareTm(tm &tm1, tm &tm2);
 // Waits for server in desired state (up - true, down - false)
-bool waitServer(const char *url, bool state);
+bool waitServer(const String &url, bool state);
 
 #endif //_TEST_SUPPORT_H_


### PR DESCRIPTION
## Proposed Changes

 All API methods with a string param allow specifying string by all basic types of :
  - Arduino `String` class
  - C `char *` or `char[]` 
  - Flash string using `F`,`PSTR` or `FPSTR` macros

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
