### PR TITLE
feat: adding isConnected to test connection persistence state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Features
+- [185](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/185) - Added diagnostic connection state getter `bool InfluxDBClient::isConnected()`
+
 ## 3.11.0 [2022-02-18]
 ### Features
  - [174](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/174),[181](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/181) - All API methods with a string param allow specifying string by all basic types:

--- a/src/HTTPService.h
+++ b/src/HTTPService.h
@@ -129,6 +129,8 @@ public:
     uint32_t getLastRequestTime() const { return _lastRequestTime; }
     // Returns response of last failed call.
     String getLastErrorMessage() const { return _pConnInfo->lastError; }
+    // Returns true if HTTP connection is kept open
+    bool isConnected() const { return _httpClient && _httpClient->connected(); }
 };
 
 #endif //_HTTP_SERVICE_H_

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -164,7 +164,8 @@ class InfluxDBClient {
     // Enables/disables streaming write. This allows sending large batches without allocating buffer.
     // It is about 50% slower than writing by allocated buffer (default);
     void setStreamWrite(bool enable = true);
-    // 
+    // Returns true if HTTP connection is kept open (connection reuse must be set to true)
+    bool isConnected() const { return _service && _service->isConnected(); }
   protected:
     // Checks params and sets up security, if needed.
     // Returns true in case of success, otherwise false


### PR DESCRIPTION
## Proposed Changes

Added diagnostic connection state getter `bool InfluxDBClient::isConnected()`.  
Useful when setting connection reuse to `true`. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
