### PR TITLE
fix: timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixes
+- [193](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/193) - Automatically adjusting point timestamp  according to the setting of write precision. 
+
 ## 3.12.0 [2022-03-21]
 ### Features
 - [185](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/185) - Added diagnostic server connection state getter `bool InfluxDBClient::isConnected()`

--- a/README.md
+++ b/README.md
@@ -676,10 +676,10 @@ boolean success = influx.write();
 ## Troubleshooting
 All db methods return status. Value `false` means something went wrong. Call `getLastErrorMessage()` to get the error message.
 
-When error message doesn't help to explain the bad behavior, go to the library sources and in the file `src/InfluxDBClient.cpp` uncomment line 32:
+When error message doesn't help to explain the bad behavior, go to the library sources and in the file `src/util/debug.h` uncomment line 33:
 ```cpp
 // Uncomment bellow in case of a problem and rebuild sketch
-#define INFLUXDB_CLIENT_DEBUG
+#define INFLUXDB_CLIENT_DEBUG_ENABLE
 ```
 Then upload your sketch again and see the debug output in the Serial Monitor.
 

--- a/src/BucketsClient.cpp
+++ b/src/BucketsClient.cpp
@@ -27,7 +27,6 @@
 #include "BucketsClient.h"
 #include "util/helpers.h"
 
-//#define INFLUXDB_CLIENT_DEBUG_ENABLE
 #include "util/debug.h"
 
 static const char *propTemplate PROGMEM = "\"%s\":";

--- a/src/HTTPService.cpp
+++ b/src/HTTPService.cpp
@@ -3,8 +3,6 @@
 #include "Platform.h"
 #include "Version.h"
 
-// Uncomment bellow in case of a problem and rebuild sketch
-//#define INFLUXDB_CLIENT_DEBUG_ENABLE
 #include "util/debug.h"
 
 static const char UserAgent[] PROGMEM = "influxdb-client-arduino/" INFLUXDB_CLIENT_VERSION " (" INFLUXDB_CLIENT_PLATFORM " " INFLUXDB_CLIENT_PLATFORM_VERSION ")";

--- a/src/InfluxData.cpp
+++ b/src/InfluxData.cpp
@@ -29,7 +29,8 @@
 
 void InfluxData::setTimestamp(long int seconds) 
 { 
-    _timestamp = timeStampToString(seconds) + "000000000"; 
+    _timestamp = timeStampToString(seconds,9);
+    strcat(_timestamp, "000000000"); 
 }
 
  String InfluxData::toString() const { 

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -28,8 +28,6 @@
 #include "Platform.h"
 #include "Version.h"
 
-// Uncomment bellow in case of a problem and rebuild sketch
-//#define INFLUXDB_CLIENT_DEBUG_ENABLE
 #include "util/debug.h"
 
 static const char TooEarlyMessage[] PROGMEM = "Cannot send request yet because of applied retry strategy. Remaining ";

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -285,16 +285,48 @@ void InfluxDBClient::reserveBuffer(int size) {
     }
 }
 
+void InfluxDBClient::addZerosToTimestamp(Point &point, int zeroes) {
+    char *ts = point._timestamp, *s;
+    point._timestamp = new char[strlen(point._timestamp) + 1 + zeroes];
+    strcpy(point._timestamp, ts);
+    s = point._timestamp+strlen(ts);
+    for(int i=0;i<zeroes;i++) {
+        *s++ = '0';
+    }
+    *s = 0;
+    delete [] ts;
+}
+
+void InfluxDBClient::checkPrecisions(Point & point) {
+    if(_writeOptions._writePrecision != WritePrecision::NoTime) {
+        if(!point.hasTime()) {
+            point.setTime(_writeOptions._writePrecision);
+        // Check different write precisions
+        } else if(point._tsWritePrecision != WritePrecision::NoTime && point._tsWritePrecision != _writeOptions._writePrecision) {
+            int diff = int(point._tsWritePrecision) - int(_writeOptions._writePrecision);
+            if(diff > 0) { //point has higher precision, cut 
+                point._timestamp[strlen(point._timestamp)-diff*3] = 0;
+            } else { //point has lower precision, add zeroes
+                addZerosToTimestamp(point, diff*-3);
+            }
+        }
+    // check someone set WritePrecision on point and not on client. NS precision is ok, cause it is default on server
+    } else if(point.hasTime() && point._tsWritePrecision != WritePrecision::NoTime && point._tsWritePrecision != WritePrecision::NS) {
+        int diff = int(WritePrecision::NS) - int(point._tsWritePrecision);
+        addZerosToTimestamp(point, diff*3);
+    } 
+}
+
 bool InfluxDBClient::writePoint(Point & point) {
     if (point.hasFields()) {
-        if(_writeOptions._writePrecision != WritePrecision::NoTime && !point.hasTime()) {
-            point.setTime(_writeOptions._writePrecision);
-        }
+        checkPrecisions(point);
         String line = pointToLineProtocol(point);
         return writeRecord(line);
     }
     return false;
 }
+
+
 
 InfluxDBClient::Batch::Batch(uint16_t size):_size(size) {  
     buffer = new char*[size]; 

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -263,6 +263,10 @@ class InfluxDBClient {
     //  flashOnlyFull - whether to flush only full batches
     // Returns true if successful, false in case of any error 
     bool flushBufferInternal(bool flashOnlyFull);
+    // Checks precision of point and mofifies if needed
+    void checkPrecisions(Point & point);
+    // helper which adds zeroes to timestamo of point to increase precision
+    static void addZerosToTimestamp(Point &point, int zeroes);
 };
 
 

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -50,6 +50,7 @@ class Test;
  * Automaticaly retries failed writes during next write, if server is overloaded.
  */
 class InfluxDBClient {
+  friend class Test;
   public:
     // Creates InfluxDBClient unconfigured instance. 
     // Call to setConnectionParams is required to set up client 
@@ -221,7 +222,6 @@ class InfluxDBClient {
         virtual size_t write(uint8_t data) override;
 
     };
-  friend class Test;
     ConnectionInfo _connInfo;  
     // Cached full write url
     String _writeUrl;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -32,8 +32,12 @@ WriteOptions& WriteOptions::addDefaultTag(const String &name, const String &valu
     if(_defaultTags.length() > 0) {
         _defaultTags += ',';
     }
-    _defaultTags += escapeKey(name);
+    char *s = escapeKey(name);
+    _defaultTags += s;
+    delete [] s;
+    s = escapeKey(value);
     _defaultTags += '=';
-    _defaultTags += escapeKey(value);
+    _defaultTags += s;
+    delete [] s;
     return *this; 
 }

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -32,6 +32,7 @@ Point::Point(const String & measurement)
 {
     _measurement = escapeKey(measurement, false);
     _timestamp = nullptr;
+    _tsWritePrecision = WritePrecision::NoTime;
 }
 
 Point::~Point() {
@@ -171,6 +172,7 @@ void  Point::setTime(WritePrecision precision) {
             setTime((char *)nullptr);
             break;
     }
+    _tsWritePrecision = precision;
 }
 
 void  Point::setTime(unsigned long long timestamp) {
@@ -187,7 +189,7 @@ void Point::setTime(const char *timestamp) {
 
 void Point::setTime(char *timestamp) {
     delete [] _timestamp;
-    timestamp = timestamp;
+    _timestamp = timestamp;
 }
 
 void  Point::clearFields() {

--- a/src/Point.h
+++ b/src/Point.h
@@ -39,6 +39,7 @@ class Point {
 friend class InfluxDBClient;
   public:
     Point(const String &measurement);
+    virtual ~Point();
     // Adds string tag 
     void addTag(const String &name, String value);
     // Add field with various types
@@ -62,6 +63,8 @@ friend class InfluxDBClient;
     void setTime(unsigned long long timestamp);
     // Set timestamp in offset since epoch (1.1.1970 00:00:00). Correct precision must be set InfluxDBClient::setWriteOptions.
     void setTime(const String &timestamp);
+    // Set timestamp in offset since epoch (1.1.1970 00:00:00). Correct precision must be set InfluxDBClient::setWriteOptions.
+    void setTime(const char *timestamp);
     // Clear all fields. Usefull for reusing point  
     void clearFields();
     // Clear tags
@@ -71,19 +74,21 @@ friend class InfluxDBClient;
     // True if a point contains at least one tag
     bool hasTags() const   { return _tags.length() > 0; }
     // True if a point contains timestamp
-    bool hasTime() const   { return _timestamp.length() > 0; }
+    bool hasTime() const   { return strLen(_timestamp) > 0; }
     // Creates line protocol with optionally added tags
     String toLineProtocol(const String &includeTags = "") const;
     // returns current timestamp
     String getTime() const { return _timestamp; } 
   protected:
-    String _measurement;
+    char *_measurement;
     String _tags;
     String _fields;
-    String _timestamp;
+    char *_timestamp;
   protected:    
     // method for formating field into line protocol
     void putField(const String &name, const String &value);
+    // set timestamp
+    void setTime(char *timestamp);
     // Creates line protocol string
     String createLineProtocol(const String &incTags) const;
 };

--- a/src/Point.h
+++ b/src/Point.h
@@ -84,6 +84,7 @@ friend class InfluxDBClient;
     String _tags;
     String _fields;
     char *_timestamp;
+    WritePrecision _tsWritePrecision;
   protected:    
     // method for formating field into line protocol
     void putField(const String &name, const String &value);

--- a/src/WritePrecision.h
+++ b/src/WritePrecision.h
@@ -27,7 +27,7 @@
 #ifndef _WRITE_PRECISION_H_
 #define _WRITE_PRECISION_H_
 // Enum WritePrecision defines constants for specifying InfluxDB write prcecision
-enum class WritePrecision  {
+enum class WritePrecision:uint8_t  {
   // Specifyies that points has no timestamp (default). Server will assign timestamp. 
   NoTime = 0,
   // Seconds

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -29,6 +29,9 @@
 
 #include <Arduino.h>
 
+// Uncomment bellow in case of a problem and rebuild sketch
+//#define INFLUXDB_CLIENT_DEBUG_ENABLE
+
 #ifdef INFLUXDB_CLIENT_DEBUG_ENABLE
 # define INFLUXDB_CLIENT_DEBUG(fmt, ...) Serial.printf("%.03f ",millis()/1000.0f);Serial.printf_P( (PGM_P)PSTR(fmt), ## __VA_ARGS__ )
 #else

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -68,36 +68,34 @@ unsigned long long getTimeStamp(struct timeval *tv, int secFracDigits) {
     return tsVal;
 }
 
-String timeStampToString(unsigned long long timestamp) {
-    static char buff[50];
-    snprintf(buff, 50, "%llu", timestamp);
-    return String(buff);
+char *timeStampToString(unsigned long long timestamp, int extraCharsSpace) {
+    //22 is max long long string length (18)
+    char *buff = new char[22+extraCharsSpace+1];
+    snprintf(buff, 22, "%llu", timestamp);
+    return buff;
 }
 
-String escapeKey(const String &key, bool escapeEqual) {
-    String ret;
-    ret.reserve(key.length()+5); //5 is estimate of  chars needs to escape,
+static char escapeChars[] = "=\r\n\t ,";
 
-    for (char c: key)
-    {
-        switch (c)
-        {
-            case '\r':
-            case '\n':
-            case '\t':
-            case ' ':
-            case ',':
-                ret += '\\';
-                break;
-            case '=':
-                if(escapeEqual) {
-                    ret += '\\';
-                }
-                break;
+char *escapeKey(const String &key, bool escapeEqual) {
+    char c,*ret,*d,*s = (char *)key.c_str();
+    int n = 0;
+    while ((c = *s++)) {
+        if(strchr(escapeEqual?escapeChars:escapeChars+1, c)) {
+            n++;
         }
-        ret += c;
     }
-    return ret;
+    ret = new char[key.length()+n+1];
+    s = (char *)key.c_str();
+    d = ret;
+    while ((c = *s++)) {
+       if (strchr(escapeEqual?escapeChars:escapeChars+1,c)) {
+           *d++ = '\\';
+      }
+      *d++ = c;
+   }
+   *d = 0;
+   return ret;
 }
 
 String escapeValue(const char *value) {
@@ -174,4 +172,17 @@ uint8_t getNumLength(long long l) {
         l /=10;
     } while(l);
     return c;
+}
+
+char *cloneStr(const char *str) {
+  char *ret = new char[strlen(str)+1];
+  strcpy(ret, str);
+  return ret;
+}
+
+size_t strLen(const char *str) {
+    if(!str) {
+        return 0;
+    }
+    return strlen(str);
 }

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -39,10 +39,10 @@ void timeSync(const char *tzInfo, const char* ntpServer1, const char* ntpServer2
 unsigned long long getTimeStamp(struct timeval *tv, int secFracDigits = 3);
 
 // Converts unsigned long long timestamp to String
-String timeStampToString(unsigned long long timestamp);
+char *timeStampToString(unsigned long long timestamp, int extraCharsSpace = 0);
 
 // Escape invalid chars in measurement, tag key, tag value and field key
-String escapeKey(const String &key, bool escapeEqual = true);
+char *escapeKey(const String &key, bool escapeEqual = true);
 
 // Escape invalid chars in field value
 String escapeValue(const char *value);
@@ -54,5 +54,10 @@ bool isValidID(const char *idString);
 const char *bool2string(bool val);
 // Returns number of digits
 uint8_t getNumLength(long long l);
+// Like strdup, but uses new
+char *cloneStr(const char *str);
+// Like strlen, but accepts nullptr
+size_t strLen(const char *str);
+
 
 #endif //_INFLUXDB_CLIENT_HELPERS_H

--- a/test/Test.h
+++ b/test/Test.h
@@ -60,6 +60,7 @@ private: // tests
     static void testUserAgent();
     static void testFailedWrites();
     static void testTimestamp();
+    static void testTimestampAdjustment();
     static void testHTTPReadTimeout();
     static void testRetryOnFailedConnection();
     static void testRetryOnFailedConnectionWithFlush();

--- a/test/TestBase.cpp
+++ b/test/TestBase.cpp
@@ -43,7 +43,7 @@ Point *TestBase::createPoint(const String &measurement) {
     return point;
 }
 
-bool testAssertm(int line, bool state,String message) {
+bool testAssertm(int line, bool state, const String &message) {
   if(!state) {
     ++TestBase::failures;
     Serial.printf("Assert failure line %d%s%s\n", line, message.length()>0?": ":"",message.c_str());

--- a/test/TestBase.h
+++ b/test/TestBase.h
@@ -56,7 +56,7 @@ public:
     static Point *createPoint(const String &measurement);
 };
 
-bool testAssertm(int line, bool state,String message);
+bool testAssertm(int line, bool state,const String &message);
 bool testAssert(int line, bool state);
 
 #endif //_E2E_TEST_H_

--- a/test/test.ino
+++ b/test/test.ino
@@ -34,11 +34,7 @@
 #include "E2ETest.h"
 
 void setup() {
-#if defined(ESP8266)
-    Serial.begin(74880);
-#else
     Serial.begin(115200);
-#endif    
     delay(2000);
     Serial.println("Initializing tests");
     Serial.println(" Compiled on "  __DATE__ " " __TIME__);


### PR DESCRIPTION
Closes #168 

## Proposed Changes

Automatically adjusting point timestamp according to the setting of write precision. If no precision is set for client, timestamp is adjusted to nanoseconds by adding zeroes to match the default server precision



## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
