### PR TITLE
fix: backward compatible compilation of Stream API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+##  unreleased
+### Fixes
+- [200](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/200) - Backward compatible compilation. Solves _marked 'override', but does not override_ errors.
+
 ##  3.12.2 [2022-09-30]
 ### Fixes
 - [198](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/198) - Effective passing Point by value

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -204,17 +204,17 @@ class InfluxDBClient {
       public:
         BatchStreamer(Batch *batch) ;
         virtual ~BatchStreamer() {};
+        // Clears pointers to start reading from beginning
+        void reset();
 
           // Stream overrides
         virtual int available() override;
 
-        virtual int availableForWrite() override;
+        virtual int availableForWrite();
 
         virtual int read() override;
-#if defined(ESP8266)        
-        virtual int read(uint8_t* buffer, size_t len) override;
-#endif
-        virtual size_t readBytes(char* buffer, size_t len) override;
+        virtual int read(uint8_t* buffer, size_t len);
+        virtual size_t readBytes(char* buffer, size_t len);
 
         virtual void flush() override {};
         virtual int peek()  override;


### PR DESCRIPTION
Closes #196 

## Proposed Changes

Removing the strict _override_ keyword to avoid compilation errors on older cores. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
