### PR TITLE
Feat precision only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ##  unreleased
 ### Features
-- [201](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/201) - Added option to specify timestamp precision and do not send timestamp. Set using `WriteOption::useServerTimestamptrue)`.
+- [202](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/202) - Added option to specify timestamp precision and do not send timestamp. Set using `WriteOption::useServerTimestamptrue)`.
 
 ### Fixes
 - [200](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/200) - Backward compatible compilation. Solves _marked 'override', but does not override_ errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ##  unreleased
+### Features
+- [201](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/201) - Added option to specify timestamp precision and do not send timestamp. Set using `WriteOption::useServerTimestamptrue)`.
+
 ### Fixes
 - [200](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/200) - Backward compatible compilation. Solves _marked 'override', but does not override_ errors.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The client has to be configured with a time precision. The default settings is t
 client.setWriteOptions(WriteOptions().writePrecision(WritePrecision::MS));
 ```
 When a write precision is configured, the client will automatically assign the current time to the timestamp of each written point which doesn't have a timestamp assigned.
+Automated assigning of timestamp can be turned off by using `WriteOption::useServerTimestamp(true)`. Client will still specify a timestamp precision for a server.
 
 If you want to manage timestamp on your own, there are several ways to set the timestamp explicitly.
 - `setTime(WritePrecision writePrecision)` - Sets the timestamp to the actual time in the desired precision. The same precision must set in WriteOptions.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,5 @@
-; CanAirIO Sensorlib
+; InfluxDB Arduino Client
 ;
-; Full guide and details: https://github.com/kike-canaries/canairio_sensorlib
-
 
 [platformio]
 src_dir = ./test/
@@ -11,10 +9,11 @@ framework = arduino
 upload_speed = 1500000
 monitor_speed = 115200
 monitor_filters = time
+lib_ignore = WiFiNINA
 build_flags =
     -D CORE_DEBUG_LEVEL=0
-lib_deps =
-    https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino.git
+lib_extra_dirs =
+    ../
 
 [esp32_common]
 platform = espressif32
@@ -22,8 +21,12 @@ board = esp32dev
 framework = ${env.framework}
 upload_speed = ${env.upload_speed}
 monitor_speed = ${env.monitor_speed}
-lib_deps = ${env.lib_deps}
-build_flags =
+lib_ignore =  ${env.lib_ignore}
+lib_extra_dirs = ${env.lib_extra_dirs}
+lib_deps =
+    WiFi
+    HTTPClient
+build_flags = 
     ${env.build_flags}
 
 [esp8266_common]
@@ -33,8 +36,12 @@ board = esp12e
 monitor_speed = ${env.monitor_speed}
 build_flags =
     ${env.build_flags}
-lib_deps = 
-    ${env.lib_deps}
+lib_deps =
+    ESP8266WiFi
+    ESP8266HTTPClient    
+lib_ignore =  ${env.lib_ignore}  
+lib_extra_dirs = 
+    ${env.lib_extra_dirs}
 
 [env:esp8266BasicTest]
 extends = esp8266_common

--- a/src/InfluxDbClient.cpp
+++ b/src/InfluxDbClient.cpp
@@ -226,6 +226,7 @@ bool InfluxDBClient::setWriteOptions(const WriteOptions & writeOptions) {
     _writeOptions._maxRetryInterval = writeOptions._maxRetryInterval;
     _writeOptions._maxRetryAttempts = writeOptions._maxRetryAttempts;
     _writeOptions._defaultTags = writeOptions._defaultTags;
+    _writeOptions._useServerTimestamp = writeOptions._useServerTimestamp;
     return true;
 }
 
@@ -531,7 +532,7 @@ void  InfluxDBClient::dropCurrentBatch() {
 }
 
 String InfluxDBClient::pointToLineProtocol(const Point& point) {
-    return point.createLineProtocol(_writeOptions._defaultTags);
+    return point.createLineProtocol(_writeOptions._defaultTags, _writeOptions._useServerTimestamp);
 }
 
 bool InfluxDBClient::validateConnection() {

--- a/src/InfluxDbClient.h
+++ b/src/InfluxDbClient.h
@@ -99,7 +99,7 @@ class InfluxDBClient {
     // Returns true if setting was successful. Otherwise check getLastErrorMessage() for an error.
     // Example: 
     //    client.setHTTPOptions(HTTPOptions().httpReadTimeout(20000)).
-      bool setHTTPOptions(const HTTPOptions &httpOptions);
+    bool setHTTPOptions(const HTTPOptions &httpOptions);
     // Sets connection parameters for InfluxDB 2
     // Must be called before calling any method initiating a connection to server.
     // serverUrl - url of the InfluxDB 2 server (e.g. https//localhost:8086)

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -146,7 +146,7 @@ String Point::toLineProtocol(const String &includeTags) const {
     return createLineProtocol(includeTags);
 }
 
-String Point::createLineProtocol(const String &incTags) const {
+String Point::createLineProtocol(const String &incTags, bool excludeTimestamp) const {
     String line;
     line.reserve(strLen(_data->measurement) + 1 + incTags.length() + 1 + _data->tags.length() + 1 + _data->fields.length() + 1 + strLen(_data->timestamp));
     line += _data->measurement;
@@ -162,14 +162,14 @@ String Point::createLineProtocol(const String &incTags) const {
         line += " ";
         line += _data->fields;
     }
-    if(hasTime()) {
+    if(hasTime() && !excludeTimestamp) {
         line += " ";
         line += _data->timestamp;
     }
     return line;
  }
 
-void  Point::setTime(WritePrecision precision) {
+void Point::setTime(WritePrecision precision) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     

--- a/src/Point.h
+++ b/src/Point.h
@@ -100,6 +100,6 @@ friend class InfluxDBClient;
     // set timestamp
     void setTime(char *timestamp);
     // Creates line protocol string
-    String createLineProtocol(const String &incTags) const;
+    String createLineProtocol(const String &incTags, bool excludeTimestamp = false) const;
 };
 #endif //_POINT_H_

--- a/test/Test.h
+++ b/test/Test.h
@@ -44,6 +44,7 @@ private: // tests
     static void testOldAPI();
     static void testBatch();
     static void testLineProtocol();
+    static void testUseServerTimestamp();
     static void testFluxTypes();
     static void testFluxTypesSerialization();
     static void testFluxParserEmpty();

--- a/test/server/server.js
+++ b/test/server/server.js
@@ -169,6 +169,12 @@ app.post(prefix + '/api/v2/write', (req,res) => {
                             console.log("Set permanentError: " + permanentError);
                             res.status(permanentError).send("bad request");
                             break;
+                        case 'check-precision':
+                            const precision = req.query['precision'];
+                            if(precision !== point.tags['precision'] && !(!precision && point.tags['precision']=='no')) {
+                                res.status(400).send("bad precision " + precision);
+                            }
+                            break;
                     }
                     
                 }


### PR DESCRIPTION
Closes #201 

## Proposed Changes

Added `WriteOption::useServerTimestamptrue)` to specify timestamp precision and do not send timestamp.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
