### PR TITLE
fix: allow setting of options without connection params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+##  unreleased
+### Fixes
+- [210](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/210) - Allow setting of options without previously set connection params
+
 ##  3.13.0 [2022-10-14]
 ### Features
 - [202](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/202) - Added option to specify timestamp precision and do not send timestamp. Set using `WriteOption::useServerTimestamptrue)`.

--- a/src/HTTPService.cpp
+++ b/src/HTTPService.cpp
@@ -51,7 +51,7 @@ HTTPService::HTTPService(ConnectionInfo *pConnInfo):_pConnInfo(pConnInfo) {
   if(!_httpClient) {
     _httpClient = new HTTPClient;
   }
-  _httpClient->setReuse(_httpOptions._connectionReuse);
+  _httpClient->setReuse(_pConnInfo->httpOptions._connectionReuse);
 
   _httpClient->setUserAgent(FPSTR(UserAgent));
 };
@@ -74,15 +74,14 @@ HTTPService::~HTTPService() {
 }
 
 
-void HTTPService::setHTTPOptions(const HTTPOptions & httpOptions) {
-    _httpOptions = httpOptions;
-    if(!_httpClient) {
-        _httpClient = new HTTPClient;
-    }
-    _httpClient->setReuse(_httpOptions._connectionReuse);
-    _httpClient->setTimeout(_httpOptions._httpReadTimeout);
+void HTTPService::setHTTPOptions() {
+  if(!_httpClient) {
+    _httpClient = new HTTPClient;
+  }
+  _httpClient->setReuse(_pConnInfo->httpOptions._connectionReuse);
+  _httpClient->setTimeout(_pConnInfo->httpOptions._httpReadTimeout);
 #if defined(ESP32) 
-     _httpClient->setConnectTimeout(_httpOptions._httpReadTimeout);
+  _httpClient->setConnectTimeout(_pConnInfo->httpOptions._httpReadTimeout);
 #endif
 }
 

--- a/src/HTTPService.h
+++ b/src/HTTPService.h
@@ -62,6 +62,8 @@ struct ConnectionInfo {
     bool insecure;
     // Error message of last failed operation
     String lastError;
+    // HTTP options
+    HTTPOptions httpOptions;
 };
 
 /**
@@ -89,8 +91,7 @@ friend class Test;
 #endif
     // Store retry timeout suggested by server after last request
     int _lastRetryAfter = 0;     
-     // HTTP options
-    HTTPOptions _httpOptions;
+   
 protected:
     // Sets request params
     bool beforeRequest(const char *url);
@@ -104,13 +105,10 @@ public:
     HTTPService(ConnectionInfo *pConnInfo);
     // Clean instance on deletion
     ~HTTPService();
-    // Sets custom HTTP options. See HTTPOptions doc for more info. 
-    // Must be called before calling any method initiating a connection to server.
-    // Example: 
-    //    service.setHTTPOptions(HTTPOptions().httpReadTimeout(20000)).
-    void setHTTPOptions(const HTTPOptions &httpOptions);
+    // Propagates http options to http client.
+    void setHTTPOptions();
     // Returns current HTTPOption
-    HTTPOptions &getHTTPOptions() { return _httpOptions; }
+    HTTPOptions &getHTTPOptions() { return _pConnInfo->httpOptions; }
     // Performs HTTP POST by sending data. On success calls response call back  
     bool doPOST(const char *url, const char *data, const char *contentType, int expectedCode, httpResponseCallback cb);
     // Performs HTTP POST by sending stream. On success calls response call back  

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -41,3 +41,16 @@ WriteOptions& WriteOptions::addDefaultTag(const String &name, const String &valu
     delete [] s;
     return *this; 
 }
+
+void WriteOptions::printTo(Print &dest) const {
+    dest.println("WriteOptions:");
+    dest.print("\t_precision: "); dest.println((uint8_t)_writePrecision);
+    dest.print("\t_batchSize: "); dest.println(_batchSize);
+    dest.print("\t_bufferSize: "); dest.println(_bufferSize);
+    dest.print("\t_flushInterval: "); dest.println(_flushInterval);
+    dest.print("\t_retryInterval: "); dest.println(_retryInterval);
+    dest.print("\t_maxRetryInterval: "); dest.println(_maxRetryInterval);
+    dest.print("\t_maxRetryAttempts: "); dest.println(_maxRetryAttempts);
+    dest.print("\t_defaultTags: "); dest.println(_defaultTags);
+    dest.print("\t_useServerTimestamp: "); dest.println(_useServerTimestamp);
+}

--- a/src/Options.h
+++ b/src/Options.h
@@ -101,6 +101,8 @@ public:
     WriteOptions& clearDefaultTags() { _defaultTags = (char *)nullptr; return *this; }
     // If timestamp precision is set and useServerTimestamp  is true, timestamp from point is not sent, or assigned.
     WriteOptions& useServerTimestamp(bool useServerTimestamp) { _useServerTimestamp = useServerTimestamp; return *this; }
+    // prints options values to a Print device. E.g. opts.printTo(Serial);
+    void printTo(Print &dest) const;
 };
 
 /**

--- a/test/Test.h
+++ b/test/Test.h
@@ -39,7 +39,7 @@ private: //helpers
 private: // tests
     static void testUtils();
     static void testOptions();
-    static void testEcaping();
+    static void testEscaping();
     static void testPoint();
     static void testOldAPI();
     static void testBatch();
@@ -51,7 +51,7 @@ private: // tests
     static void testFluxParserSingleTable();
     static void testFluxParserNilValue();
     static void testFluxParserMultiTables(bool chunked);
-    static void testFluxParserErrorDiffentColumnsNum();
+    static void testFluxParserErrorDifferentColumnsNum();
     static void testFluxParserFluxError();
     static void testFluxParserInvalidDatatype();
     static void testFluxParserMissingDatatype();

--- a/test/test.ino
+++ b/test/test.ino
@@ -81,6 +81,10 @@ void initInet() {
     while(!wifiOk && j<3) {
         Serial.print("Connecting to wifi " INFLUXDB_CLIENT_TESTING_SSID);
         WiFi.begin(INFLUXDB_CLIENT_TESTING_SSID, INFLUXDB_CLIENT_TESTING_PASS);
+#ifdef ARDUINO_LOLIN_C3_MINI 
+        // Necessary for Lolin C3 mini v1.0
+        WiFi.setTxPower(WIFI_POWER_8_5dBm);
+#endif        
         while ((WiFi.status() != WL_CONNECTED) && (i < 30)) {
             Serial.print(".");
             delay(300);


### PR DESCRIPTION
Closes #206

## Proposed Changes

- Fixed lazy initialization to be done in a connection function
- Fixed typos in test names

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
