### PR TITLE
fix: ESP32 Core 3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 3.13.2 [2024-06-04]
+### Fixes
+- [236](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/236) - Fix compilation problem on ESP32 Core 3.0.0
+
 ## 3.13.1 [2023-03-08]
 ### Fixes
 - [210](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/pull/210) - Allow setting of options without previously set connection params

--- a/src/HTTPService.h
+++ b/src/HTTPService.h
@@ -33,6 +33,8 @@
 # include <ESP8266HTTPClient.h>
 #elif defined(ESP32)
 # include <HTTPClient.h>
+# include <WiFiClient.h>
+# include <WiFiClientSecure.h>
 #else
 # error "This library currently supports only ESP8266 and ESP32."
 #endif
@@ -132,3 +134,4 @@ public:
 };
 
 #endif //_HTTP_SERVICE_H_
+


### PR DESCRIPTION
Closes #226 

## Proposed Changes

Added explicit includes which were part of `HTTPClient.h` in ESP32 core 2.x.x

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
