### PR TITLE
Adding support for configurable BearSSL buffer sizes, useful for devices with small heap

### DIFF
--- a/src/HTTPService.cpp
+++ b/src/HTTPService.cpp
@@ -33,6 +33,14 @@ HTTPService::HTTPService(ConnectionInfo *pConnInfo):_pConnInfo(pConnInfo) {
       }
     }
     checkMFLN(wifiClientSec, pConnInfo->serverUrl);
+    // If explicit SSL buffer sizes have been configured via HTTPOptions::sslBufferSize(),
+    // override the MFLN result. This is the recommended workaround for ESP8266 OOM
+    // crashes caused by BearSSL's default 16KB+16KB buffers exhausting the heap.
+    // See: https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino/issues/230
+    if(pConnInfo->httpOptions._sslRxBufferSize > 0 || pConnInfo->httpOptions._sslTxBufferSize > 0) {
+        wifiClientSec->setBufferSizes(pConnInfo->httpOptions._sslRxBufferSize,
+                                      pConnInfo->httpOptions._sslTxBufferSize);
+    }
 #elif defined(ESP32)
     WiFiClientSecure *wifiClientSec = new WiFiClientSecure;  
     if (pConnInfo->insecure) {

--- a/src/Options.h
+++ b/src/Options.h
@@ -120,15 +120,45 @@ private:
     // Timeout [ms] for reading server response.
     // Default 5000ms  
     int _httpReadTimeout;
+#if defined(ESP8266)
+    // BearSSL TLS receive buffer size in bytes.
+    // BearSSL's default is 16KB RX + 16KB TX = 32KB total. Combined with the
+    // ~12-14KB the TLS handshake itself needs, this exceeds the ~30-40KB of
+    // free heap available at runtime on an ESP8266, causing an OOM crash.
+    // The MFLN fallback in the library only helps when the server advertises
+    // MFLN support. For example most InfluxDB servers do not so the large
+    // default buffers remain and the device crashes.
+    // Set to 512 for write-only use cases (sufficient for InfluxDB line-protocol
+    // payloads). Use a larger value, e.g. 1024, if you need to read larger
+    // server responses such as query results.
+    // 0 = use MFLN negotiation (default, existing behaviour).
+    uint16_t _sslRxBufferSize;
+    // BearSSL TLS transmit buffer size in bytes.
+    // 512 is sufficient for normal write operations. Increase if sending
+    // large batch payloads, adjust according to your available heap.
+    // 0 = use MFLN negotiation (default, existing behaviour).
+    uint16_t _sslTxBufferSize;
+#endif // ESP8266
 public:
     HTTPOptions():
         _connectionReuse(false),
-        _httpReadTimeout(5000) {
-        }
+        _httpReadTimeout(5000)
+#if defined(ESP8266)
+        ,_sslRxBufferSize(0),
+        _sslTxBufferSize(0)
+#endif // ESP8266
+        {}
     // Set true if HTTP connection should be kept open. Usable for frequent writes.
     HTTPOptions& connectionReuse(bool connectionReuse) { _connectionReuse = connectionReuse; return *this; }
     // Sets timeout after which HTTP stops reading
     HTTPOptions& httpReadTimeout(int httpReadTimeoutMs) { _httpReadTimeout = httpReadTimeoutMs; return *this; }
+#if defined(ESP8266)
+    // Sets BearSSL TLS buffer sizes independently for RX and TX (ESP8266 only).
+    // Overrides MFLN negotiation. Recommended: sslBufferSize(512, 512) for
+    // write-only use cases. Use a larger rxSize (e.g. 1024) when reading
+    // larger server responses such as query results.
+    HTTPOptions& sslBufferSize(uint16_t rxSize, uint16_t txSize) { _sslRxBufferSize = rxSize; _sslTxBufferSize = txSize; return *this; }
+#endif // ESP8266
 };
 
 #endif //_OPTIONS_H_


### PR DESCRIPTION
Closes #230 and #231 

## Proposed Changes

Adds sslBufferSize(rxSize, txSize) to HTTPOptions, allowing ESP8266 users to override BearSSL's default TLS buffer sizes to prevent OOM crashes when using HTTPS.

Root cause: BearSSL allocates its RX and TX buffers lazily at TLS handshake time. The defaults are 16KB RX + 16KB TX = 32KB total. Combined with the ~12-14KB the handshake itself needs, this exceeds the ~30-40KB of free heap available at runtime on an ESP8266, causing an OOM crash. The existing MFLN workaround does not help in practice because most InfluxDB servers do not advertise MFLN support, leaving the full 32KB buffers in place.

Fix: After MFLN negotiation, if the user has configured explicit buffer sizes via HTTPOptions::sslBufferSize(), those values override the MFLN result. Default is 0 (no override), so existing behaviour is completely unchanged.

Measured heap consumption during TLS handshake on ESP8266 ESP-12F:

PATCHED  setBufferSizes(512, 512) - handshake cost:  ~6KB
ORIGINAL default BearSSL buffers  - handshake cost: ~25KB
16KB remaining is not enough when the rest of the application (web server, LittleFS, sensors) is also loaded, which is the crash scenario.

Usage:

influxdb.setHTTPOptions(
    HTTPOptions()
        .connectionReuse(false)
        .sslBufferSize(512, 512));  // 512 RX + 512 TX, sufficient for line-protocol writes
Use a larger rxSize (e.g. 1024) if you need to read larger server responses such as query results.

Note: setSSLVersion(BR_TLS12, BR_TLS12) is not included as BearSSL on ESP8266 does not support TLS 1.3 - TLS 1.2 is already the effective maximum.

This patch has been running in production on two ESP8266 devices for nearly two years.

Change log entry:
- Add `HTTPOptions::sslBufferSize(rx, tx)` to fix OOM crashes on HTTPS connections (#230)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
