### PR TITLE
fix: correct fractional seconds normalization in RFC3339 parser

### DIFF
--- a/src/query/FluxParser.cpp
+++ b/src/query/FluxParser.cpp
@@ -226,7 +226,12 @@ FluxDateTime *FluxQueryResult::convertRfc3339(String &value, const char *type) {
             String secParts = value.substring(dot+1, tail);
             fracts = strtoul((const char *) secParts.c_str(), NULL, 10);
             if(len < 6) {
-                fracts *= 10^(6-len); 
+                // Normalize to microseconds by multiplying by 10 for each missing digit.
+                // e.g. ".037" (3 digits) -> 37 * 10 * 10 * 10 = 37000 us
+                // Note: do NOT use 10^n here - in C++ ^ is bitwise XOR, not exponentiation.
+                for(int i = len; i < 6; i++) {
+                    fracts *= 10;
+                }
             }
         }
     } else {


### PR DESCRIPTION
In convertRfc3339(), the intent was to normalize a sub-6-digit fractional seconds value to microseconds by multiplying by a power of 10. The code used the ^ operator for this, which in C++ is bitwise XOR - not exponentiation. There is no exponentiation operator in C++.

This caused incorrect microsecond values for any RFC3339 timestamp with fewer than 6 fractional digits. The most common real-world case is 3-digit millisecond precision (e.g. '2020-02-18T10:34:08.135Z'), where the multiplier becomes 10 XOR 3 = 9 instead of 1000, producing a result roughly 111x too small.

Timestamps with 6 digits (microseconds) or 7-9 digits (nanoseconds, truncated to 6 before this branch) are not affected.

The struct tm fields (year, month, day, hour, minute, second) are parsed separately by sscanf and are always correct. Only the sub-second microseconds field is affected.

## Proposed Changes

replace the single XOR expression with an explicit multiply loop, which avoids pulling in <math.h> for pow() and keeps the arithmetic integer throughout.

## Checklist

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
